### PR TITLE
fix(deploy): run service as ubuntu deploy user, node from official tarball

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,12 +24,13 @@ Then:
 
 1. `sudo cp /tmp/feed1-src/.env.example /opt/feed1/.env && sudo nano /opt/feed1/.env`
    — fill in `DISCORD_TOKEN` (PROD bot), `LASTFM_API_KEY`, `OWNER_ID`, `PREFIX`,
-   `ERROR_CHANNEL_ID`, `STATUS_CHANNEL_ID`. Then `sudo chown feed1:feed1 /opt/feed1/.env && sudo chmod 600 /opt/feed1/.env`.
+   `ERROR_CHANNEL_ID`, `STATUS_CHANNEL_ID`. Then `sudo chmod 600 /opt/feed1/.env`.
+   The app and its files are owned by `ubuntu` (the deploy user), which the service also runs as.
 2. Create a deploy SSH keypair (`ssh-keygen -t ed25519 -f deploy_key`), append `deploy_key.pub`
    to `~ubuntu/.ssh/authorized_keys` on the VM.
 3. Allow the deploy user to restart the service without a password (`sudo visudo`):
    ```
-   ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl stop feed1, /usr/bin/systemctl start feed1
+   ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl stop feed1, /usr/bin/systemctl start feed1, /usr/bin/systemctl restart feed1
    ```
 4. GitHub repo secrets (Settings → Secrets → Actions):
    - `DEPLOY_HOST` = VM public IP

--- a/deploy/feed1.service
+++ b/deploy/feed1.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=feed1
+User=ubuntu
 WorkingDirectory=/opt/feed1
 EnvironmentFile=/opt/feed1/.env
 ExecStart=/usr/bin/node dist/index.js

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,24 +1,37 @@
 #!/usr/bin/env bash
 # One-time provisioning for the feed1 host (Ubuntu 22.04/24.04, x64 or ARM).
-# Run as a sudo-capable user: bash provision.sh
+# Run as the deploy user with sudo: bash provision.sh
 set -euo pipefail
 
 APP_DIR=/opt/feed1
+DEPLOY_USER="${SUDO_USER:-ubuntu}"
 
 echo "== installing Node 22 =="
+# NodeSource's setup script 403s from some cloud IPs, so install the official
+# binary tarball directly.
 if ! command -v node >/dev/null || [[ "$(node --version)" != v22* && "$(node --version)" != v2[3-9]* ]]; then
-  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-  sudo apt-get install -y nodejs
+  case "$(uname -m)" in
+    aarch64) NODE_ARCH=arm64 ;;
+    x86_64)  NODE_ARCH=x64 ;;
+    *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+  esac
+  NODE_TARBALL=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
+    | grep -oE "node-v22\.[0-9]+\.[0-9]+-linux-${NODE_ARCH}\.tar\.xz" | head -1)
+  curl -fsSLO "https://nodejs.org/dist/latest-v22.x/${NODE_TARBALL}"
+  sudo tar -xJf "${NODE_TARBALL}" -C /usr/local --strip-components=1
+  sudo ln -sf /usr/local/bin/node /usr/bin/node
+  sudo ln -sf /usr/local/bin/npm /usr/bin/npm
+  sudo ln -sf /usr/local/bin/npx /usr/bin/npx
+  rm -f "${NODE_TARBALL}"
 fi
 
 echo "== canvas build dependencies (fallback if prebuilt binaries are unavailable) =="
 sudo apt-get update
 sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev rsync
 
-echo "== app user and directory =="
-sudo useradd --system --create-home --shell /usr/sbin/nologin feed1 2>/dev/null || true
+echo "== app directory =="
 sudo mkdir -p "$APP_DIR/.data/backups"
-sudo chown -R feed1:feed1 "$APP_DIR"
+sudo chown -R "$DEPLOY_USER:$DEPLOY_USER" "$APP_DIR"
 
 echo "== systemd unit =="
 sudo cp "$(dirname "$0")/feed1.service" /etc/systemd/system/feed1.service
@@ -28,10 +41,9 @@ sudo systemctl enable feed1
 cat <<'NEXT'
 == next steps ==
 1. Create /opt/feed1/.env (copy .env.example) with the PROD token, Last.fm key,
-   OWNER_ID, ERROR_CHANNEL_ID, STATUS_CHANNEL_ID. chmod 600, chown feed1.
-2. Add the deploy user's SSH public key to ~/.ssh/authorized_keys and allow
-   passwordless 'sudo systemctl stop feed1' / 'start feed1' via visudo:
-     deploy ALL=(root) NOPASSWD: /usr/bin/systemctl stop feed1, /usr/bin/systemctl start feed1
-3. Set GitHub repo secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY, DEPLOY_PATH=/opt/feed1
+   OWNER_ID, ERROR_CHANNEL_ID, STATUS_CHANNEL_ID. chmod 600.
+2. Allow the deploy user to restart the service without a password (visudo):
+     ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl stop feed1, /usr/bin/systemctl start feed1, /usr/bin/systemctl restart feed1
+3. Set GitHub repo secrets: DEPLOY_HOST, DEPLOY_USER=ubuntu, DEPLOY_SSH_KEY, DEPLOY_PATH=/opt/feed1
 4. Push to master — the deploy workflow does the rest.
 NEXT


### PR DESCRIPTION
## What & why

First deploy to the Oracle VM failed at the rsync step: `mkdir: cannot create directory '/opt/feed1/incoming': Permission denied`. The deploy connects as `ubuntu` but `provision.sh` chowned `/opt/feed1` to a separate `feed1` system user, so the deploy user couldn't write. Fix: run the service as `ubuntu` so deploy-user and run-user are the same (fine for a single-app box).

Also swaps the Node 22 install from the NodeSource setup script (403s from Oracle cloud IPs) to the official nodejs.org binary tarball, arch-detected.

The live VM was already patched by hand; this brings the repo in line so a fresh provision works.