### PR TITLE
fix(deploy): exclude incoming/ from swap rsync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
             mkdir -p "$APP/.data/backups"
             cp "$APP/.data/feed1.sqlite" "$APP/.data/backups/predeploy_$(date +%Y%m%dT%H%M%S).sqlite"
           fi
-          rsync -a --delete --exclude '.data' --exclude '.env' --exclude 'node_modules' "$APP/incoming/" "$APP/"
+          rsync -a --delete --exclude '.data' --exclude '.env' --exclude 'node_modules' --exclude 'incoming' "$APP/incoming/" "$APP/"
           cd "$APP"
           npm ci --omit=dev
           sudo systemctl start feed1


### PR DESCRIPTION
## What & why

Second deploy failure. The swap step ran `rsync -a --delete $APP/incoming/ $APP/`, but `incoming/` is inside `$APP` (`/opt/feed1`), so `--delete` removed it mid-transfer and every source file reported "file has vanished" (rsync exit 24). Add `--exclude 'incoming'` so the staging dir survives the sync.