### PR TITLE
fix(whoknows): avoid gateway rate limit by using member cache

### DIFF
--- a/src/crowns/members.ts
+++ b/src/crowns/members.ts
@@ -9,7 +9,14 @@ export async function gatherRegisteredMembers(
   db: Db,
   guild: Guild,
 ): Promise<RegisteredMember[]> {
-  const members = await guild.members.fetch();
+  // A full members.fetch() hits the gateway REQUEST_GUILD_MEMBERS op, which
+  // Discord rate-limits; doing it on every command trips GatewayRateLimitError
+  // on rapid calls. Fetch only when the cache is missing members — the
+  // GuildMembers intent keeps it current afterwards.
+  if (guild.members.cache.size < guild.memberCount) {
+    await guild.members.fetch().catch(() => undefined);
+  }
+  const members = guild.members.cache;
   const ids = [...members.filter((m) => !m.user.bot).keys()];
   if (ids.length === 0) return [];
 

--- a/test/commands/whoknows.test.ts
+++ b/test/commands/whoknows.test.ts
@@ -36,10 +36,23 @@ function guildWithMembers(fake: FakeMessage, ids: string[]) {
   const collection = new Collection(
     ids.map((id) => [id, { user: { id, bot: false, tag: `${id}#0`, username: id } }]),
   );
-  (fake.message as unknown as { guild: { id: string; name: string; members: unknown } }).guild = {
+  const cache = new Collection<string, unknown>();
+  const members = {
+    cache,
+    fetch: () => {
+      for (const [id, m] of collection) cache.set(id, m);
+      return Promise.resolve(collection);
+    },
+  };
+  (
+    fake.message as unknown as {
+      guild: { id: string; name: string; members: unknown; memberCount: number };
+    }
+  ).guild = {
     id: 'guild-1',
     name: 'Test Guild',
-    members: { fetch: () => Promise.resolve(collection) },
+    members,
+    memberCount: ids.length,
   };
 }
 

--- a/test/crowns/worker.test.ts
+++ b/test/crowns/worker.test.ts
@@ -17,17 +17,20 @@ function makeDb() {
 function fakeClient(): Client {
   return {
     guilds: {
-      fetch: () =>
-        Promise.resolve({
+      fetch: () => {
+        const cache = new Collection<string, unknown>([
+          ['u1', { user: { id: 'u1', bot: false, tag: 'u1#0' } }],
+        ]);
+        return Promise.resolve({
           id: 'g1',
           name: 'Test Guild',
+          memberCount: cache.size,
           members: {
-            fetch: () =>
-              Promise.resolve(
-                new Collection([['u1', { user: { id: 'u1', bot: false, tag: 'u1#0' } }]]),
-              ),
+            cache,
+            fetch: () => Promise.resolve(cache),
           },
-        }),
+        });
+      },
     },
   } as unknown as Client;
 }


### PR DESCRIPTION
## What & why

Live `-wk`/`-a` intermittently failed with "There was an error trying to execute the command." Server logs showed `GatewayRateLimitError: Request with opcode 8 was rate limited` — `gatherRegisteredMembers` called `guild.members.fetch()` (a full gateway REQUEST_GUILD_MEMBERS pull) on **every** invocation, so rapid calls tripped Discord's rate limit on that op.

Fix: only do the full fetch when the member cache is incomplete (`cache.size < memberCount`); otherwise read from cache, which the GuildMembers intent keeps current. Repeated calls now issue zero gateway member requests.