### PR TITLE
fix(lastfm): autocorrect=1 so crowns key on canonical artist name

### DIFF
--- a/src/lastfm/client.ts
+++ b/src/lastfm/client.ts
@@ -126,13 +126,15 @@ export class LastfmClient {
   }
 
   getArtistInfo(artist: string, username?: string): Promise<ArtistInfo> {
-    const params: Record<string, string> = { artist };
+    // autocorrect maps variants ("the grateful dead") to the canonical artist
+    // ("Grateful Dead") so crowns key on one name instead of splitting.
+    const params: Record<string, string> = { artist, autocorrect: '1' };
     if (username !== undefined) params.username = username;
     return this.request('artist.getinfo', params);
   }
 
   getAlbumInfo(artist: string, album: string, username?: string): Promise<AlbumInfo> {
-    const params: Record<string, string> = { artist, album };
+    const params: Record<string, string> = { artist, album, autocorrect: '1' };
     if (username !== undefined) params.username = username;
     return this.request('album.getinfo', params);
   }


### PR DESCRIPTION
## What & why

`-wk grateful dead` and `-wk the grateful dead` were settling **two** crowns for what is one Last.fm artist. The crown correctly keys on Last.fm's returned `artist.name`, but `artist.getinfo`/`album.getinfo` were called without `autocorrect`, so Last.fm echoed the queried variant instead of the canonical artist (its own UI says *"Did you mean Grateful Dead?"*). Passing `autocorrect=1` resolves variants to the canonical name → one crown.