### PR TITLE
feat(admin): -logs command to read recent journald logs

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,7 +1,8 @@
-import { EmbedBuilder, PermissionFlagsBits } from 'discord.js';
+import { AttachmentBuilder, EmbedBuilder, PermissionFlagsBits } from 'discord.js';
 import type { Command } from '../core/command.js';
 import { disableCommand, enableCommand } from '../core/disables.js';
 import { sendable } from '../core/channel.js';
+import { parseLogsArgs, readLogs } from '../ops/logs.js';
 
 const PROTECTED = new Set(['enable', 'disable', 'help']);
 
@@ -131,6 +132,43 @@ const restart: Command = {
   },
 };
 
+const logs: Command = {
+  name: 'logs',
+  description:
+    'Shows recent bot logs from journald. `-e` for errors only, `-n <count>` for how many ' +
+    'lines (default 10, max 500). Owner only.',
+  usage: 'logs [-e] [-n <count>]',
+  hidden: true,
+  ownerOnly: true,
+  guildOnly: false,
+  async run({ message, args }) {
+    const opts = parseLogsArgs(args);
+    let lines: string[];
+    try {
+      lines = await readLogs(opts);
+    } catch (error) {
+      return message.reply(
+        `couldn't read logs: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const kind = opts.errorsOnly ? 'error ' : '';
+    if (lines.length === 0) {
+      return message.reply(`no ${kind}log lines found.`);
+    }
+
+    const body = lines.join('\n');
+    const header = `last ${lines.length} ${kind}log line${lines.length === 1 ? '' : 's'}`;
+    if (body.length <= 1850) {
+      return message.reply(`${header}:\n\`\`\`\n${body}\n\`\`\``);
+    }
+    const file = new AttachmentBuilder(Buffer.from(body, 'utf8'), {
+      name: `feed1-${opts.errorsOnly ? 'errors' : 'logs'}.txt`,
+    });
+    return message.reply({ content: `${header} (attached):`, files: [file] });
+  },
+};
+
 export const adminCommands: Command[] = [
   makeToggle('disable'),
   makeToggle('enable'),
@@ -138,4 +176,5 @@ export const adminCommands: Command[] = [
   ping,
   botinfo,
   restart,
+  logs,
 ];

--- a/src/ops/logs.ts
+++ b/src/ops/logs.ts
@@ -1,0 +1,64 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const LOGS_DEFAULT = 10;
+export const LOGS_MAX = 500;
+
+export const SYSTEMD_UNIT = process.env.SYSTEMD_UNIT ?? 'feed1';
+
+// journald lines are prefixed (timestamp host unit[pid]:), so these match against
+// the whole line: error keywords, common network error codes, and V8 stack frames.
+const ERROR_KEYWORDS = /error|exception|unhandled|rejection|ETIMEDOUT|ECONN|EADDR|\bthrow\b/i;
+const STACK_FRAME = /\bat\s+\S.*\(/;
+
+export function isErrorLine(line: string): boolean {
+  return ERROR_KEYWORDS.test(line) || STACK_FRAME.test(line);
+}
+
+export interface LogsOptions {
+  errorsOnly: boolean;
+  count: number;
+}
+
+export function parseLogsArgs(args: string[]): LogsOptions {
+  const errorsOnly = args.includes('-e') || args.includes('--errors');
+  let count = LOGS_DEFAULT;
+  const ni = args.findIndex((a) => a === '-n' || a === '--lines');
+  if (ni !== -1 && args[ni + 1] !== undefined) {
+    const parsed = Number.parseInt(args[ni + 1]!, 10);
+    if (Number.isFinite(parsed)) count = parsed;
+  }
+  count = Math.max(1, Math.min(LOGS_MAX, count));
+  return { errorsOnly, count };
+}
+
+export type JournalRunner = (unit: string, lines: number) => Promise<string>;
+
+const defaultRunner: JournalRunner = async (unit, lines) => {
+  const { stdout } = await execFileAsync('journalctl', [
+    '-u',
+    unit,
+    '--no-pager',
+    '-o',
+    'short-iso',
+    '-n',
+    String(lines),
+  ]);
+  return stdout;
+};
+
+/** Fetch the newest `count` log lines (error-filtered when requested). */
+export async function readLogs(
+  opts: LogsOptions,
+  unit: string = SYSTEMD_UNIT,
+  run: JournalRunner = defaultRunner,
+): Promise<string[]> {
+  // when filtering errors we need a wider window to find `count` matches
+  const fetch = opts.errorsOnly ? Math.min(Math.max(opts.count * 50, 2000), 10_000) : opts.count;
+  const raw = await run(unit, fetch);
+  let lines = raw.split('\n').filter((l) => l.trim().length > 0);
+  if (opts.errorsOnly) lines = lines.filter(isErrorLine);
+  return lines.slice(-opts.count);
+}

--- a/test/ops/logs.test.ts
+++ b/test/ops/logs.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LOGS_DEFAULT,
+  LOGS_MAX,
+  isErrorLine,
+  parseLogsArgs,
+  readLogs,
+  type JournalRunner,
+} from '../../src/ops/logs.js';
+
+describe('parseLogsArgs', () => {
+  it('defaults to 10 lines, all logs', () => {
+    expect(parseLogsArgs([])).toEqual({ errorsOnly: false, count: LOGS_DEFAULT });
+  });
+
+  it('reads -e as errors-only', () => {
+    expect(parseLogsArgs(['-e'])).toEqual({ errorsOnly: true, count: LOGS_DEFAULT });
+  });
+
+  it('reads -n <count>', () => {
+    expect(parseLogsArgs(['-n', '100'])).toEqual({ errorsOnly: false, count: 100 });
+  });
+
+  it('combines -e and -n in any order', () => {
+    expect(parseLogsArgs(['-e', '-n', '200'])).toEqual({ errorsOnly: true, count: 200 });
+    expect(parseLogsArgs(['-n', '200', '-e'])).toEqual({ errorsOnly: true, count: 200 });
+  });
+
+  it('clamps count to [1, LOGS_MAX] and ignores garbage', () => {
+    expect(parseLogsArgs(['-n', '99999']).count).toBe(LOGS_MAX);
+    expect(parseLogsArgs(['-n', '0']).count).toBe(1);
+    expect(parseLogsArgs(['-n', 'abc']).count).toBe(LOGS_DEFAULT);
+    expect(parseLogsArgs(['-n']).count).toBe(LOGS_DEFAULT);
+  });
+});
+
+describe('isErrorLine', () => {
+  const stamp = '2026-07-27T20:36:57+0000 host feed1[8236]:';
+  it('matches error messages and stack frames', () => {
+    expect(isErrorLine(`${stamp} [command wk] GatewayRateLimitError: rate limited`)).toBe(true);
+    expect(isErrorLine(`${stamp}     at Client.rateLimitHandler (/opt/feed1/x.js:287:18)`)).toBe(
+      true,
+    );
+    expect(isErrorLine(`${stamp} [scan] Last.fm error 8 on artist.getinfo: ECONNRESET`)).toBe(true);
+  });
+  it('ignores ordinary info lines', () => {
+    expect(isErrorLine(`${stamp} feed1 logged in as feed1#3067`)).toBe(false);
+    expect(isErrorLine(`${stamp} backup complete → .data/backups/feed1_x.sqlite`)).toBe(false);
+    expect(isErrorLine(`${stamp} users: 53 | crowns: 2`)).toBe(false);
+  });
+});
+
+const SAMPLE = [
+  'T1 host feed1[1]: feed1 logged in as feed1#3067',
+  'T2 host feed1[1]: backup complete → x.sqlite',
+  'T3 host feed1[1]: [command wk] GatewayRateLimitError: rate limited',
+  'T4 host feed1[1]:     at Client.rateLimitHandler (/opt/feed1/x.js:287:18)',
+  'T5 host feed1[1]: users: 53',
+  'T6 host feed1[1]: [scan] Last.fm error 8 on artist.getinfo: timeout',
+].join('\n');
+
+describe('readLogs', () => {
+  const runner = (out: string): JournalRunner => () => Promise.resolve(out);
+
+  it('returns the newest N lines unfiltered', async () => {
+    const lines = await readLogs({ errorsOnly: false, count: 2 }, 'feed1', runner(SAMPLE));
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('Last.fm error 8');
+  });
+
+  it('filters to only error lines when errorsOnly', async () => {
+    const lines = await readLogs({ errorsOnly: true, count: 10 }, 'feed1', runner(SAMPLE));
+    expect(lines).toHaveLength(3);
+    expect(lines.every(isErrorLine)).toBe(true);
+    expect(lines.some((l) => l.includes('logged in'))).toBe(false);
+  });
+
+  it('takes the newest N of the filtered errors', async () => {
+    const lines = await readLogs({ errorsOnly: true, count: 1 }, 'feed1', runner(SAMPLE));
+    expect(lines).toEqual(['T6 host feed1[1]: [scan] Last.fm error 8 on artist.getinfo: timeout']);
+  });
+
+  it('drops blank lines', async () => {
+    const lines = await readLogs({ errorsOnly: false, count: 10 }, 'feed1', runner('a\n\n\nb\n'));
+    expect(lines).toEqual(['a', 'b']);
+  });
+
+  it('requests a wider window when filtering errors', async () => {
+    let requested = 0;
+    const spy: JournalRunner = (_u, n) => {
+      requested = n;
+      return Promise.resolve(SAMPLE);
+    };
+    await readLogs({ errorsOnly: true, count: 5 }, 'feed1', spy);
+    expect(requested).toBeGreaterThanOrEqual(2000);
+    await readLogs({ errorsOnly: false, count: 5 }, 'feed1', spy);
+    expect(requested).toBe(5);
+  });
+});


### PR DESCRIPTION
## What & why

Owner-only `-logs` command for debugging the live bot from Discord without SSHing in:

- `-logs` → last 10 log lines
- `-logs -e` → last 10 **error** lines
- `-logs -n 100` → last 100 lines
- `-logs -e -n 200` → last 200 error lines

Reads from `journalctl -u feed1` (the service user is in the `adm` group, so no sudo). `-e` filters by log **content** (error keywords + stack frames) because journald priority isn't reliable for our stderr. Output inlines in a code block when short, else attaches as a `.txt` file (so large `-n` doesn't hit the 2000-char limit).

Gated by the existing `ownerOnly`/`OWNER_ID` mechanism — you're already the owner, so **no new admin schema/field**. When multiple admins are needed later, that's a one-line change to an `ADMIN_IDS` env check. Logic lives in `src/ops/logs.ts` with 12 unit tests.