### PR TITLE
chore: rename to feed1, retarget deploy to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # feed1
 
-A Last.fm Discord bot — the TypeScript rewrite of FMcord. Now-playing, top-album charts,
+A Last.fm Discord bot written in TypeScript. Now-playing, top-album charts,
 who-knows rankings, a full crowns system, and RateYourMusic link tooling, on prefix
 commands (`-fm`, `-w`, `-wk`, ...).
 
@@ -25,7 +25,7 @@ npm run dev
 
 ## Deployment
 
-GitHub Actions deploys `master` to an Oracle Cloud free-tier VM over SSH.
+GitHub Actions deploys `main` to an Oracle Cloud free-tier VM over SSH.
 See [deploy/README.md](deploy/README.md) for the one-time setup.
 
 ## Commands

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,7 +16,7 @@
 
 ```sh
 ssh ubuntu@<vm-ip>
-git clone https://github.com/mxttbennett/FMcord.git /tmp/feed1-src   # or scp the deploy/ dir
+git clone https://github.com/mxttbennett/feed1.git /tmp/feed1-src   # or scp the deploy/ dir
 sudo bash /tmp/feed1-src/deploy/provision.sh
 ```
 
@@ -40,7 +40,7 @@ Then:
 
 ## 3. Every deploy after that
 
-Push to `master`. The `deploy` workflow tests, builds, stops the service, backs up the
+Push to `main`. The `deploy` workflow tests, builds, stops the service, backs up the
 SQLite DB, syncs the new build, installs production deps, and restarts. Migrations run
 automatically at app startup.
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -45,5 +45,5 @@ cat <<'NEXT'
 2. Allow the deploy user to restart the service without a password (visudo):
      ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl stop feed1, /usr/bin/systemctl start feed1, /usr/bin/systemctl restart feed1
 3. Set GitHub repo secrets: DEPLOY_HOST, DEPLOY_USER=ubuntu, DEPLOY_SSH_KEY, DEPLOY_PATH=/opt/feed1
-4. Push to master — the deploy workflow does the rest.
+4. Push to main — the deploy workflow does the rest.
 NEXT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feed1",
   "version": "2.0.0",
-  "description": "feed1 — a Last.fm Discord bot (rewrite of FMcord)",
+  "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",
   "engines": {

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -109,7 +109,7 @@ const botinfo: Command = {
     const client = message.client;
     const embed = new EmbedBuilder()
       .setTitle('feed1')
-      .setDescription('a Last.fm Discord bot — rewrite of FMcord')
+      .setDescription('a Last.fm Discord bot')
       .addFields(
         { name: 'servers', value: String(client.guilds.cache.size), inline: true },
         { name: 'uptime', value: `${Math.floor(process.uptime() / 60)} min`, inline: true },


### PR DESCRIPTION
## What & why

Follows the repo rename (FMcord → feed1) and default-branch rename (master → main):

- `deploy.yml` now triggers on `main` (was `master`) — keeps auto-deploy working post-rename
- clone URL in `deploy/README.md` → `mxttbennett/feed1`
- `master` → `main` in deploy docs
- dropped the "FMcord" name from user-facing copy (README, `package.json` description, `-botinfo`)

The archived `.claude/plans/feed1-rewrite.md` keeps its FMcord references — it's a historical record of the rewrite. Merging this validates the deploy pipeline still fires on `main`.