### PR TITLE
feat(fm): show artist ranks alongside album ranks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# feed1
+
+Last.fm Discord bot. TypeScript (strict, ESM), discord.js v14 prefix commands, better-sqlite3 +
+Drizzle, vitest. A 2.0 rewrite of a JavaScript bot preserved at the `legacy` tag.
+
+## Layout
+
+| Path | What lives there |
+|---|---|
+| `src/commands/` | one file per command, each exporting a `Command` (`name`, `aliases`, `run`) |
+| `src/core/` | router, command registry, config (zod-validated env), db handle, error reporter, mutex |
+| `src/lastfm/` | API client + raw response types; **all** Last.fm calls go through `LastfmClient` |
+| `src/db/` | Drizzle schema; migrations in `drizzle/` are applied at startup |
+| `src/crowns/` | crown service + background job worker |
+| `src/charts/`, `src/ops/` | node-canvas chart rendering; backup and log-reading helpers |
+
+Pure formatting logic is split into a sibling module (`fm.ts` → `fmFormat.ts`) so it can be unit
+tested without Discord or HTTP.
+
+## Conventions
+
+- **Legacy output fidelity is a feature.** Footer text, `&ast` asterisk escaping, singular/plural
+  rank labels and similar quirks are deliberately byte-compatible with the old bot. Don't "fix"
+  odd-looking strings — they're reproduced on purpose, and tests assert them exactly.
+- **One shared rate limiter** gates every Last.fm request process-wide (`src/lastfm/rateLimiter.ts`,
+  250 ms between request starts). Commands that page through large result sets are the heavy
+  neighbours; keep page budgets deliberate.
+- Long-running enrichment edits a sent embed in place rather than blocking on a complete result.
+  Edits that only *add* optional detail should swallow their failures so a hiccup can't discard an
+  already-good message.
+- Numbers arrive from Last.fm as strings — parse with `toInt()` from `src/lastfm/types.ts`.
+- Background work (crown recalculation) is queued to the DB and drained by a worker, not done inline.
+
+## Loop
+
+```sh
+npm run dev        # tsx watch against the dev bot
+npm test           # vitest
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint src test
+npm run smoke      # drives a running dev bot over real Discord
+```
+
+Tests use `nock` with net access disabled and the fakes in `test/helpers/fake.ts` (in-memory SQLite,
+a fake `Message` recording replies/embeds/edits). No network in tests.
+
+## Deploy
+
+Merging to `main` triggers `.github/workflows/deploy.yml`: tests + build, rsync to an Oracle Cloud
+VM, DB backup, `systemctl restart feed1`. CI (typecheck, lint, test, build) runs on every PR.

--- a/src/commands/fm.ts
+++ b/src/commands/fm.ts
@@ -19,18 +19,70 @@ import {
   fmDescription,
   rankLine,
   scrobblesFooter,
-  type AlbumRanks,
+  type Ranks,
 } from './fmFormat.js';
 
+const PAGE_SIZE = 1000;
+
+interface RankBudget {
+  key: keyof Ranks;
+  period: Period;
+  pages: number;
+}
+
 /** pages of 1000 searched per period before giving up on a rank */
-const RANK_PAGES: { key: keyof AlbumRanks; period: Period; pages: number }[] = [
+const ARTIST_RANK_PAGES: RankBudget[] = [
+  { key: 'week', period: '7day', pages: 1 },
+  { key: 'month', period: '1month', pages: 1 },
+  { key: 'year', period: '12month', pages: 2 },
+  { key: 'overall', period: 'overall', pages: 3 },
+];
+
+const ALBUM_RANK_PAGES: RankBudget[] = [
   { key: 'week', period: '7day', pages: 1 },
   { key: 'month', period: '1month', pages: 1 },
   { key: 'year', period: '12month', pages: 3 },
   { key: 'overall', period: 'overall', pages: 5 },
 ];
 
-async function findAlbumRank(
+/**
+ * Albums need two fields to identify them; collapse both sides to one comparable key.
+ * The NUL joiner can't occur in a name, so "A B" + "C" can't collide with "A" + "B C".
+ */
+function albumKey(artist: string, album: string): string {
+  return `${artist}\u0000${album}`;
+}
+
+async function findRank(
+  maxPages: number,
+  target: string,
+  fetchKeys: (page: number) => Promise<string[]>,
+): Promise<number | null> {
+  const wanted = target.toUpperCase();
+  for (let page = 1; page <= maxPages; page++) {
+    const keys = await fetchKeys(page);
+    if (keys.length === 0) return null;
+    const index = keys.findIndex((key) => key.toUpperCase() === wanted);
+    if (index !== -1) return (page - 1) * PAGE_SIZE + index + 1;
+    if (keys.length < PAGE_SIZE) return null;
+  }
+  return null;
+}
+
+function findArtistRank(
+  app: AppContext,
+  lastfmUser: string,
+  period: Period,
+  maxPages: number,
+  artist: string,
+): Promise<number | null> {
+  return findRank(maxPages, artist, async (page) => {
+    const data = await app.lastfm.getTopArtists(lastfmUser, period, PAGE_SIZE, page);
+    return data.topartists.artist.map((a) => a.name);
+  });
+}
+
+function findAlbumRank(
   app: AppContext,
   lastfmUser: string,
   period: Period,
@@ -38,19 +90,10 @@ async function findAlbumRank(
   artist: string,
   album: string,
 ): Promise<number | null> {
-  for (let page = 1; page <= maxPages; page++) {
-    const data = await app.lastfm.getTopAlbums(lastfmUser, period, 1000, page);
-    const albums = data.topalbums.album;
-    if (albums.length === 0) return null;
-    const index = albums.findIndex(
-      (a) =>
-        a.artist.name.toUpperCase() === artist.toUpperCase() &&
-        a.name.toUpperCase() === album.toUpperCase(),
-    );
-    if (index !== -1) return (page - 1) * 1000 + index + 1;
-    if (albums.length < 1000) return null;
-  }
-  return null;
+  return findRank(maxPages, albumKey(artist, album), async (page) => {
+    const data = await app.lastfm.getTopAlbums(lastfmUser, period, PAGE_SIZE, page);
+    return data.topalbums.album.map((a) => albumKey(a.artist.name, a.name));
+  });
 }
 
 function baseEmbed(message: Message, lastfmUser: string, track: RecentTrack): EmbedBuilder {
@@ -146,43 +189,9 @@ export const fm: Command = {
         }
       }
 
-      let foot = scrobblesFooter(allPlays, artistPlays, albumPlays);
-      if (!nowPlaying) foot = `${NOT_PLAYING_FOOTER}\n${foot}`;
-      await sent.edit({
-        embeds: [baseEmbed(message, lastfmUser, track).setFooter({ text: foot, iconURL: crownGif })],
-      });
-
-      // phase 2: album ranks, appended once found
-      if (albumPlays !== null && albumPlays > 0 && album) {
-        const ranks: AlbumRanks = { week: null, month: null, year: null, overall: null };
-        for (const { key, period, pages } of RANK_PAGES) {
-          try {
-            ranks[key] = await findAlbumRank(
-              app,
-              lastfmUser,
-              period,
-              pages,
-              canonicalArtist,
-              canonicalAlbum,
-            );
-          } catch {
-            ranks[key] = null;
-          }
-        }
-        const line = rankLine(ranks);
-        if (line) {
-          await sent.edit({
-            embeds: [
-              baseEmbed(message, lastfmUser, track).setFooter({
-                text: foot + line,
-                iconURL: crownGif,
-              }),
-            ],
-          });
-        }
-      }
-
-      // legacy &fm recomputed crowns inline; feed1 queues the same work for the background worker
+      // legacy &fm recomputed crowns inline; feed1 queues the same work for the background worker.
+      // Enqueued before any rendering so a failed edit or rank scan can't cost the guild its
+      // crown update.
       if (message.guild) {
         enqueueCrownJob(app.db, {
           kind: 'artist',
@@ -199,6 +208,48 @@ export const fm: Command = {
             requestedBy: message.author.id,
           });
         }
+      }
+
+      let foot = scrobblesFooter(allPlays, artistPlays, albumPlays);
+      if (!nowPlaying) foot = `${NOT_PLAYING_FOOTER}\n${foot}`;
+      const render = (text: string) =>
+        baseEmbed(message, lastfmUser, track).setFooter({ text, iconURL: crownGif });
+      await sent.edit({ embeds: [render(foot)] });
+
+      // phase 2: ranks, revealed one period at a time as each scan finishes
+      const artistRanks: Ranks = { week: null, month: null, year: null, overall: null };
+      const albumRanks: Ranks = { week: null, month: null, year: null, overall: null };
+      const footerWithRanks = () =>
+        foot + rankLine(artistRanks, 'artist') + rankLine(albumRanks, 'album');
+      // a dropped rank edit must not discard the footer we already painted
+      const repaint = () =>
+        sent.edit({ embeds: [render(footerWithRanks())] }).catch(() => undefined);
+
+      const collect = async (
+        ranks: Ranks,
+        budget: RankBudget[],
+        find: (period: Period, pages: number) => Promise<number | null>,
+      ) => {
+        for (const { key, period, pages } of budget) {
+          try {
+            ranks[key] = await find(period, pages);
+          } catch {
+            ranks[key] = null;
+          }
+          if (ranks[key] !== null) await repaint();
+        }
+      };
+
+      if (artistPlays !== null && artistPlays > 0) {
+        await collect(artistRanks, ARTIST_RANK_PAGES, (period, pages) =>
+          findArtistRank(app, lastfmUser, period, pages, canonicalArtist),
+        );
+      }
+
+      if (albumPlays !== null && albumPlays > 0 && album) {
+        await collect(albumRanks, ALBUM_RANK_PAGES, (period, pages) =>
+          findAlbumRank(app, lastfmUser, period, pages, canonicalArtist, canonicalAlbum),
+        );
       }
     } catch (error) {
       await app.errors.report(error, 'fm enrichment');

--- a/src/commands/fmFormat.ts
+++ b/src/commands/fmFormat.ts
@@ -58,7 +58,7 @@ export function scrobblesFooter(
   return foot;
 }
 
-export interface AlbumRanks {
+export interface Ranks {
   week: number | null;
   month: number | null;
   year: number | null;
@@ -66,10 +66,10 @@ export interface AlbumRanks {
 }
 
 /**
- * `\nalbum ranks → w: #N | m: #N | y: #N | o: #N` for the ranks that were found.
+ * `\n<kind> ranks → w: #N | m: #N | y: #N | o: #N` for the ranks that were found.
  * Legacy quirk kept: when only the overall rank exists the label is singular (`album rank`).
  */
-export function rankLine(ranks: AlbumRanks): string {
+export function rankLine(ranks: Ranks, kind: 'artist' | 'album'): string {
   const segments: string[] = [];
   if (ranks.week !== null) segments.push(`w: #${ranks.week}`);
   if (ranks.month !== null) segments.push(`m: #${ranks.month}`);
@@ -77,5 +77,5 @@ export function rankLine(ranks: AlbumRanks): string {
   if (ranks.overall !== null) segments.push(`o: #${ranks.overall}`);
   if (segments.length === 0) return '';
   const onlyOverall = segments.length === 1 && ranks.overall !== null;
-  return `\nalbum rank${onlyOverall ? '' : 's'} → ${segments.join(' | ')}`;
+  return `\n${kind} rank${onlyOverall ? '' : 's'} → ${segments.join(' | ')}`;
 }

--- a/test/commands/fm.test.ts
+++ b/test/commands/fm.test.ts
@@ -8,17 +8,21 @@ import { LOADING_GIF, CROWN_GIF_OWN, NOT_PLAYING_FOOTER } from '../../src/comman
 
 const BASE = 'https://ws.audioscrobbler.com';
 
+const SCROBBLES = 'scrobbles → all: 5000 | artist: 250 | album: 42';
+const ARTIST_RANKS = '\nartist ranks → w: #1 | m: #1 | y: #1 | o: #1';
+const ALBUM_RANKS = '\nalbum ranks → w: #1 | m: #1 | y: #1 | o: #1';
+
 beforeAll(() => nock.disableNetConnect());
 afterEach(() => nock.cleanAll());
 
-function recentTracksBody(nowPlaying: boolean) {
+function recentTracksBody(nowPlaying: boolean, album = 'Gantz Graf') {
   return {
     recenttracks: {
       track: [
         {
           name: 'Gantz Graf',
           artist: { '#text': 'Autechre', mbid: '' },
-          album: { '#text': 'Gantz Graf', mbid: '' },
+          album: { '#text': album, mbid: '' },
           image: [
             { size: 'small', '#text': 'https://img.example/s.png' },
             { size: 'medium', '#text': 'https://img.example/m.png' },
@@ -34,12 +38,30 @@ function recentTracksBody(nowPlaying: boolean) {
   };
 }
 
-function mockLastfm(nowPlaying = true) {
+interface MockOptions {
+  nowPlaying?: boolean;
+  /** '' simulates a scrobble with no album */
+  album?: string;
+  artistPlays?: string;
+  albumPlays?: number;
+  /** make user.gettopartists fail so only album ranks can resolve */
+  topArtistsDown?: boolean;
+}
+
+function mockLastfm(opts: MockOptions = {}) {
+  const {
+    nowPlaying = true,
+    album = 'Gantz Graf',
+    artistPlays = '250',
+    albumPlays = 42,
+    topArtistsDown = false,
+  } = opts;
+
   nock(BASE)
     .persist()
     .get('/2.0/')
     .query((q) => q.method === 'user.getrecenttracks')
-    .reply(200, recentTracksBody(nowPlaying));
+    .reply(200, recentTracksBody(nowPlaying, album));
   nock(BASE)
     .persist()
     .get('/2.0/')
@@ -50,14 +72,19 @@ function mockLastfm(nowPlaying = true) {
     .get('/2.0/')
     .query((q) => q.method === 'artist.getinfo')
     .reply(200, {
-      artist: { name: 'Autechre', url: '', stats: { listeners: '1', playcount: '1', userplaycount: '250' }, image: [] },
+      artist: {
+        name: 'Autechre',
+        url: '',
+        stats: { listeners: '1', playcount: '1', userplaycount: artistPlays },
+        image: [],
+      },
     });
   nock(BASE)
     .persist()
     .get('/2.0/')
     .query((q) => q.method === 'album.getinfo')
     .reply(200, {
-      album: { name: 'Gantz Graf', artist: 'Autechre', url: '', userplaycount: 42, image: [] },
+      album: { name: 'Gantz Graf', artist: 'Autechre', url: '', userplaycount: albumPlays, image: [] },
     });
   nock(BASE)
     .persist()
@@ -74,6 +101,19 @@ function mockLastfm(nowPlaying = true) {
             url: '',
           },
         ],
+        '@attr': { total: '1' },
+      },
+    });
+
+  const topArtists = nock(BASE)
+    .persist()
+    .get('/2.0/')
+    .query((q) => q.method === 'user.gettopartists');
+  if (topArtistsDown) topArtists.reply(500, {});
+  else
+    topArtists.reply(200, {
+      topartists: {
+        artist: [{ name: 'Autechre', playcount: '250', url: '' }],
         '@attr': { total: '1' },
       },
     });
@@ -95,6 +135,10 @@ function footerIconOf(edit: unknown): string {
   return embeds[0]!.data.footer?.icon_url ?? '';
 }
 
+function lastFooter(edits: unknown[]): string {
+  return footerOf(edits[edits.length - 1]);
+}
+
 describe('&fm', () => {
   it('requires login', async () => {
     const app = makeFakeApp([fm]);
@@ -103,7 +147,7 @@ describe('&fm', () => {
     expect(fake.replies[0]).toBe(app.snippets.noLogin);
   });
 
-  it('renders loading embed first, then edits in the full footer and ranks', async () => {
+  it('renders loading embed first, then reveals ranks one period at a time', async () => {
     mockLastfm();
     const app = setup();
     const fake = makeFakeMessage({ content: '&fm' });
@@ -116,13 +160,57 @@ describe('&fm', () => {
     expect(first.data.title).toBe('**Gantz Graf**');
     expect(first.data.description).toContain('[***Gantz Graf***](');
 
-    // phase 2 + 3 edits
-    expect(fake.edits.length).toBeGreaterThanOrEqual(2);
-    expect(footerOf(fake.edits[0])).toBe('scrobbles → all: 5000 | artist: 250 | album: 42');
-    expect(footerOf(fake.edits[1])).toBe(
-      'scrobbles → all: 5000 | artist: 250 | album: 42' +
-        '\nalbum ranks → w: #1 | m: #1 | y: #1 | o: #1',
-    );
+    // one edit for the scrobbles footer, then one per resolved rank period
+    expect(fake.edits).toHaveLength(9);
+    expect(footerOf(fake.edits[0])).toBe(SCROBBLES);
+    expect(footerOf(fake.edits[1])).toBe(`${SCROBBLES}\nartist ranks → w: #1`);
+    expect(footerOf(fake.edits[2])).toBe(`${SCROBBLES}\nartist ranks → w: #1 | m: #1`);
+    expect(footerOf(fake.edits[4])).toBe(SCROBBLES + ARTIST_RANKS);
+    expect(footerOf(fake.edits[5])).toBe(`${SCROBBLES + ARTIST_RANKS}\nalbum ranks → w: #1`);
+    expect(lastFooter(fake.edits)).toBe(SCROBBLES + ARTIST_RANKS + ALBUM_RANKS);
+  });
+
+  it('shows artist ranks on a scrobble with no album', async () => {
+    mockLastfm({ album: '' });
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm' });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    const footer = lastFooter(fake.edits);
+    expect(footer).toBe('scrobbles → all: 5000 | artist: 250' + ARTIST_RANKS);
+    expect(footer).not.toContain('album ranks');
+  });
+
+  it('shows no rank lines when the user has no plays for the artist or album', async () => {
+    mockLastfm({ artistPlays: '0', albumPlays: 0 });
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm' });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(fake.edits).toHaveLength(1);
+    expect(footerOf(fake.edits[0])).toBe('scrobbles → all: 5000');
+  });
+
+  it('keeps the album rank line when the artist rank lookup fails', async () => {
+    mockLastfm({ topArtistsDown: true });
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm' });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    const footer = lastFooter(fake.edits);
+    expect(footer).toBe(SCROBBLES + ALBUM_RANKS);
+    expect(footer).not.toContain('artist ranks');
+    expect(footer).not.toContain('could not load your data.');
+  });
+
+  it('survives a dropped rank edit and still paints the final footer', async () => {
+    mockLastfm();
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm', failEditsAt: [1] });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(lastFooter(fake.edits)).toBe(SCROBBLES + ARTIST_RANKS + ALBUM_RANKS);
+    expect(app.reportedErrors).toHaveLength(0);
   });
 
   it('enqueues artist and album crown jobs instead of scanning inline', async () => {
@@ -135,6 +223,16 @@ describe('&fm', () => {
     expect(jobs).toHaveLength(2);
     expect(jobs.map((j) => j.kind).sort()).toEqual(['album', 'artist']);
     expect(jobs.every((j) => j.artistName === 'Autechre')).toBe(true);
+  });
+
+  it('still enqueues crown jobs when the footer edit fails', async () => {
+    mockLastfm();
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm', failEditsAt: [0] });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(app.db.select().from(schema.crownJobs).all()).toHaveLength(2);
+    expect(lastFooter(fake.edits)).toBe('could not load your data.');
   });
 
   it('shows the own-crown gif when the caller holds the album crown', async () => {
@@ -156,7 +254,7 @@ describe('&fm', () => {
   });
 
   it('falls back to last scrobbled with the legacy footer text', async () => {
-    mockLastfm(false);
+    mockLastfm({ nowPlaying: false });
     const app = setup();
     const fake = makeFakeMessage({ content: '&fm' });
     await fm.run({ app, message: fake.message, args: [] });

--- a/test/commands/fmFormat.test.ts
+++ b/test/commands/fmFormat.test.ts
@@ -67,24 +67,34 @@ describe('scrobblesFooter', () => {
 
 describe('rankLine', () => {
   it('joins found ranks with pipes in w/m/y/o order', () => {
-    expect(rankLine({ week: 1, month: 2, year: 3, overall: 4 })).toBe(
+    expect(rankLine({ week: 1, month: 2, year: 3, overall: 4 }, 'album')).toBe(
       '\nalbum ranks → w: #1 | m: #2 | y: #3 | o: #4',
     );
   });
 
+  it('labels artist ranks with the artist kind', () => {
+    expect(rankLine({ week: 1, month: 2, year: 3, overall: 4 }, 'artist')).toBe(
+      '\nartist ranks → w: #1 | m: #2 | y: #3 | o: #4',
+    );
+  });
+
   it('omits missing ranks', () => {
-    expect(rankLine({ week: null, month: 5, year: null, overall: 9 })).toBe(
+    expect(rankLine({ week: null, month: 5, year: null, overall: 9 }, 'album')).toBe(
       '\nalbum ranks → m: #5 | o: #9',
     );
   });
 
   it('uses the legacy singular label when only the overall rank exists', () => {
-    expect(rankLine({ week: null, month: null, year: null, overall: 7 })).toBe(
+    expect(rankLine({ week: null, month: null, year: null, overall: 7 }, 'album')).toBe(
       '\nalbum rank → o: #7',
+    );
+    expect(rankLine({ week: null, month: null, year: null, overall: 7 }, 'artist')).toBe(
+      '\nartist rank → o: #7',
     );
   });
 
   it('returns empty when nothing was found', () => {
-    expect(rankLine({ week: null, month: null, year: null, overall: null })).toBe('');
+    expect(rankLine({ week: null, month: null, year: null, overall: null }, 'album')).toBe('');
+    expect(rankLine({ week: null, month: null, year: null, overall: null }, 'artist')).toBe('');
   });
 });

--- a/test/helpers/fake.ts
+++ b/test/helpers/fake.ts
@@ -53,6 +53,8 @@ export interface FakeMessageOptions {
   channelId?: string;
   mentionUserIds?: string[];
   memberDisplayColor?: number;
+  /** 0-indexed edit calls that should reject, to exercise non-fatal edit paths */
+  failEditsAt?: number[];
 }
 
 export interface FakeMessage {
@@ -88,10 +90,14 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
     return Promise.resolve(makeSentMessage());
   };
 
+  const failEditsAt = new Set(opts.failEditsAt ?? []);
+
   function makeSentMessage() {
     return {
       edit: (payload: unknown) => {
+        const attempt = edits.length;
         edits.push(payload);
+        if (failEditsAt.has(attempt)) return Promise.reject(new Error(`edit ${attempt} failed`));
         return Promise.resolve(makeSentMessage());
       },
       react: () => Promise.resolve(),


### PR DESCRIPTION
## What & why

`-fm` showed `album ranks → …` but had no artist equivalent. This adds an `artist ranks` line above it, on the same rules. Despite feeling like a lost feature, this is new: legacy `src/commands/fm.js` only ever emitted `album ranks` / `album rank`, and `getTopArtists` appears in no pre-rewrite `fm.js` — so the album path was the model rather than a reference to port.

Artist ranks show whenever the user has plays for the artist, **including on album-less scrobbles** — previously the whole rank block was dead without an album. Each period is revealed as its scan finishes (~9 edits worst case) rather than appearing in one batch, matching the old bot's feel.

## Notable changes beyond the feature

- Album and artist rank scanning now share one page loop (`findRank`) that owns the pagination invariants — empty page, short page, `(page-1)*PAGE_SIZE + index + 1` — instead of forking them per kind.
- Rank repaints are non-fatal. With ~9 edits instead of 2, one dropped edit previously would have thrown into the outer catch and replaced a good footer with `could not load your data.` The primary scrobbles edit keeps its old fatal, reported behavior.
- Crown jobs are enqueued **before** any rendering. Previously they sat after the rank loops, so any throw during enrichment skipped them entirely — a pre-existing hole that artist ranks would have widened from ~10 requests to ~17.

## Cost

Artist budget is 1/1/2/3 pages of 1000 (album's is 1/1/3/5) since artist lists are much shorter. Worst case ~17 Last.fm requests per invocation against a process-wide 250ms limiter, so a `-fm` call is a slightly heavier neighbour for concurrent commands. An artist past #2000 for the year or #3000 overall shows no rank — a missing segment, never a wrong one, same as album ranks today.

## Testing

`npm run typecheck`, `npm run lint`, `npm test` (159 passing). New coverage: album-less scrobbles, zero-play case, per-period fetch isolation when `gettopartists` fails, a dropped rank edit still reaching the correct final footer, and crown jobs surviving a failed footer edit. The last two were mutation-checked — reverting either behavior fails its test.

Also adds the repo's missing `CLAUDE.md` (separate commit).