### PR TITLE
fix(fm): shorten the not-playing note and pin it to the footer bottom

### DIFF
--- a/src/commands/fm.ts
+++ b/src/commands/fm.ts
@@ -14,7 +14,7 @@ import {
   CROWN_GIF_OWN,
   LASTFM_DOWN_REPLY,
   LOADING_GIF,
-  NOT_PLAYING_FOOTER,
+  NOT_PLAYING_NOTE,
   escapeAsterisks,
   fmDescription,
   rankLine,
@@ -139,9 +139,13 @@ export const fm: Command = {
     const artist = track.artist['#text'];
     const album = track.album['#text'];
 
+    // trails every footer, so a stale track is flagged from the first render onward
+    const note = nowPlaying ? '' : NOT_PLAYING_NOTE;
+    const withNote = (text: string) => (note ? `${text}\n${note}` : text);
+
     // phase 1: skeleton embed with the loading footer, edited in place as data arrives
     const embed = baseEmbed(message, lastfmUser, track).setFooter({
-      text: 'loading your data...',
+      text: withNote('loading your data...'),
       iconURL: LOADING_GIF,
     });
     const sent = await sendable(message).send({ embeds: [embed] });
@@ -210,17 +214,16 @@ export const fm: Command = {
         }
       }
 
-      let foot = scrobblesFooter(allPlays, artistPlays, albumPlays);
-      if (!nowPlaying) foot = `${NOT_PLAYING_FOOTER}\n${foot}`;
+      const foot = scrobblesFooter(allPlays, artistPlays, albumPlays);
       const render = (text: string) =>
         baseEmbed(message, lastfmUser, track).setFooter({ text, iconURL: crownGif });
-      await sent.edit({ embeds: [render(foot)] });
+      await sent.edit({ embeds: [render(withNote(foot))] });
 
       // phase 2: ranks, revealed one period at a time as each scan finishes
       const artistRanks: Ranks = { week: null, month: null, year: null, overall: null };
       const albumRanks: Ranks = { week: null, month: null, year: null, overall: null };
       const footerWithRanks = () =>
-        foot + rankLine(artistRanks, 'artist') + rankLine(albumRanks, 'album');
+        withNote(foot + rankLine(artistRanks, 'artist') + rankLine(albumRanks, 'album'));
       // a dropped rank edit must not discard the footer we already painted
       const repaint = () =>
         sent.edit({ embeds: [render(footerWithRanks())] }).catch(() => undefined);
@@ -257,7 +260,7 @@ export const fm: Command = {
         .edit({
           embeds: [
             baseEmbed(message, lastfmUser, track).setFooter({
-              text: nowPlaying ? 'could not load your data.' : NOT_PLAYING_FOOTER,
+              text: withNote('could not load your data.'),
               iconURL: CROWN_GIF_DEFAULT,
             }),
           ],

--- a/src/commands/fmFormat.ts
+++ b/src/commands/fmFormat.ts
@@ -5,8 +5,7 @@ export const CROWN_GIF_DEFAULT = 'https://i.imgur.com/GBuQOhn.gif';
 export const CROWN_GIF_OWN = 'https://i.imgur.com/bCeKwDd.gif';
 export const CROWN_GIF_OTHER = 'https://i.imgur.com/Qgo8myA.gif';
 
-export const NOT_PLAYING_FOOTER =
-  'cannot fetch currently playing track.\nthis is the last track scrobbled.';
+export const NOT_PLAYING_NOTE = 'not playing → showing last scrobble';
 export const LASTFM_DOWN_REPLY =
   'an error occurred. Last.fm may be experiencing issues at the moment.';
 

--- a/test/commands/fm.test.ts
+++ b/test/commands/fm.test.ts
@@ -4,7 +4,7 @@ import type { EmbedBuilder } from 'discord.js';
 import { fm } from '../../src/commands/fm.js';
 import { schema } from '../../src/db/index.js';
 import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
-import { LOADING_GIF, CROWN_GIF_OWN, NOT_PLAYING_FOOTER } from '../../src/commands/fmFormat.js';
+import { LOADING_GIF, CROWN_GIF_OWN, NOT_PLAYING_NOTE } from '../../src/commands/fmFormat.js';
 
 const BASE = 'https://ws.audioscrobbler.com';
 
@@ -253,12 +253,38 @@ describe('&fm', () => {
     expect(footerIconOf(fake.edits[0])).toBe(CROWN_GIF_OWN);
   });
 
-  it('falls back to last scrobbled with the legacy footer text', async () => {
+  it('flags a last-scrobbled track from the first render, with the note last', async () => {
     mockLastfm({ nowPlaying: false });
     const app = setup();
     const fake = makeFakeMessage({ content: '&fm' });
     await fm.run({ app, message: fake.message, args: [] });
-    expect(footerOf(fake.edits[0])).toContain(NOT_PLAYING_FOOTER);
-    expect(footerOf(fake.edits[0])).toContain('scrobbles → all: 5000');
+
+    // the note is known before any Last.fm enrichment, so it ships with the loading embed
+    const first = fake.embeds[0] as EmbedBuilder;
+    expect(first.data.footer?.text).toBe(`loading your data...\n${NOT_PLAYING_NOTE}`);
+
+    expect(footerOf(fake.edits[0])).toBe(`${SCROBBLES}\n${NOT_PLAYING_NOTE}`);
+    expect(lastFooter(fake.edits)).toBe(
+      `${SCROBBLES + ARTIST_RANKS + ALBUM_RANKS}\n${NOT_PLAYING_NOTE}`,
+    );
+  });
+
+  it('keeps the note below the failure message when enrichment fails', async () => {
+    mockLastfm({ nowPlaying: false });
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm', failEditsAt: [0] });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(lastFooter(fake.edits)).toBe(`could not load your data.\n${NOT_PLAYING_NOTE}`);
+  });
+
+  it('shows no note at all while a track is playing', async () => {
+    mockLastfm();
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm' });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect((fake.embeds[0] as EmbedBuilder).data.footer?.text).toBe('loading your data...');
+    expect(lastFooter(fake.edits)).not.toContain(NOT_PLAYING_NOTE);
   });
 });


### PR DESCRIPTION
## What & why

The not-playing footer was two wordy lines sitting *above* the data, and it only appeared after enrichment finished:

```
cannot fetch currently playing track.
this is the last track scrobbled.
scrobbles → all: 162294 | artist: 37 | album: 3
```

Now it's one line, trailing the data, and present from the moment the embed posts:

```
loading your data...                                    ← first render, immediately
not playing → showing last scrobble
```
```
scrobbles → all: 162294 | artist: 37 | album: 3         ← final
artist ranks → w: #2 | m: #14 | y: #201 | o: #877
album ranks → w: #4 | m: #27 | y: #709 | o: #3918
not playing → showing last scrobble
```

`nowPlaying` was already resolved before the phase-1 send, so the instant reveal costs no extra request — the note just wasn't wired in there. A single `withNote()` helper applies it to all three render paths (loading, ranks, error fallback), which is what keeps it last as rank lines accumulate above it.

## One behavior change worth a look

The error fallback used to be `nowPlaying ? 'could not load your data.' : NOT_PLAYING_FOOTER` — so a not-playing enrichment failure showed *only* the not-playing text and silently hid the failure. It now shows both. That branch had no test coverage; it does now.

## Testing

`npm run typecheck`, `npm run lint`, `npm test` (161 passing). New cases cover the note on the initial embed, the note as the final footer's last line, the two-line error fallback, and no note at all while a track is playing. Mutation-checked: moving the note back to the top fails two of them.

`rankLine`'s leading-newline contract is deliberately left alone — appending the note doesn't require touching it, and rewriting that contract for a copy tweak risks a run-together footer that types can't catch.