### PR TITLE
feat(ci): cut a versioned GitHub Release on every deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
-      - run: npx eslint src test
+      - run: npx eslint src test scripts
       - run: npx vitest run
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -21,6 +25,62 @@ jobs:
       - run: npm ci
       - run: npx vitest run
       - run: npm run build
+
+      # Versioning is push-only: a manual workflow_dispatch redeploys the
+      # checked-out tree as-is, without minting a version or a release.
+      - name: Compute release version
+        id: release
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+          version=$(
+            LATEST_TAG="$latest" \
+            SUBJECT="$(git log -1 --format=%s "$GITHUB_SHA")" \
+            BODY="$(git log -1 --format=%b "$GITHUB_SHA")" \
+            FALLBACK="$(node -p "require('./package.json').version")" \
+            npx tsx scripts/nextVersion.ts
+          )
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "::error::tag v$version already exists — refusing to reuse a released version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "${latest:-<no tags>} -> v$version"
+
+      - name: Stamp the version into the artifact
+        if: steps.release.outputs.version != ''
+        run: npm version "${{ steps.release.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      # Pushed before the deploy so the release tag points at a commit whose
+      # package.json is the one that actually shipped.
+      - name: Commit and push the version bump
+        id: writeback
+        if: steps.release.outputs.version != ''
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- package.json package-lock.json; then
+            echo "version already ${{ steps.release.outputs.version }} — nothing to write back"
+            echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package.json package-lock.json
+          git commit -m "chore(release): ${{ steps.release.outputs.tag }} [skip ci]"
+          git fetch origin main
+          # Never rebase onto a newer main — that would publish this version's
+          # package.json on top of the next release's code. Skip instead; tags
+          # stay authoritative and the next deploy reconciles.
+          if [ "$(git rev-parse origin/main)" != "$GITHUB_SHA" ]; then
+            echo "::warning::main moved during this deploy — skipping the version write-back"
+            echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git push origin HEAD:main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up SSH
         run: |
@@ -55,3 +115,15 @@ jobs:
           sleep 5
           systemctl is-active feed1
           EOF
+
+      # Only after the service is confirmed up, so a release always means a
+      # deploy that came back healthy.
+      - name: Create the GitHub Release
+        if: steps.release.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.release.outputs.tag }}" \
+            --title "${{ steps.release.outputs.tag }}" \
+            --generate-notes \
+            --target "${{ steps.writeback.outputs.sha }}"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ npm run dev
 
 ## Deployment
 
-GitHub Actions deploys `main` to an Oracle Cloud free-tier VM over SSH.
-See [deploy/README.md](deploy/README.md) for the one-time setup.
+GitHub Actions deploys `main` to an Oracle Cloud free-tier VM over SSH. Each merge is
+versioned from its commit subject and published as a [GitHub Release](../../releases).
+See [deploy/README.md](deploy/README.md) for the one-time setup and the versioning rules.
 
 ## Commands
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,6 +45,25 @@ Push to `main`. The `deploy` workflow tests, builds, stops the service, backs up
 SQLite DB, syncs the new build, installs production deps, and restarts. Migrations run
 automatically at app startup.
 
+## Versioning & releases
+
+Every push to `main` mints a version and cuts a GitHub Release. The bump comes from the
+squash-merge commit subject: `feat(...)` → minor, `<type>!:` or `BREAKING CHANGE` in the body
+→ major, anything else (including non-conventional subjects) → patch. The logic lives in
+`scripts/nextVersion.ts` and is unit-tested; it sits outside `src/` so it never ships to the VM.
+
+**Git tags are the source of truth**, not `package.json` — the next version is computed from the
+highest `v*` tag, so a stale checkout or a skipped write-back can't duplicate or skip a version.
+The workflow stamps the version into `package.json`, commits it to `main`, *then* deploys, so
+the release tag always points at the tree that actually shipped (which is what makes rolling
+back to a tag viable). The Release itself is created only after `systemctl is-active` passes.
+
+- Which version is live: `node -p "require('/opt/feed1/package.json').version"`, or `-botinfo` in Discord.
+- A manual `workflow_dispatch` run deploys the checked-out tree as-is — no version, no release.
+- `::warning::main moved during this deploy` means another PR merged mid-deploy, so the version
+  write-back was skipped rather than rebased onto newer code. The tag and Release are still
+  correct; `main`'s `package.json` is just one version behind and the next deploy reconciles it.
+
 ## Discord portal checklist (once per bot application)
 
 - Bot → Privileged Gateway Intents: enable **Server Members Intent** and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,8 @@
 2. Pick a **home region** close to you (e.g. `us-ashburn-1`). It can't be changed later.
 3. Create instance: **Compute → Instances → Create**.
    - Image: **Ubuntu 24.04**.
-   - Shape: **Ampere A1.Flex** (Always Free eligible), e.g. 2 OCPU / 12 GB — anything within the free 4 OCPU / 24 GB.
+   - Shape: **Ampere A1.Flex** (Always Free eligible) — anything within the free 4 OCPU / 24 GB.
+     The current host runs 1 OCPU / 6 GB, which is plenty; scale up for free if a build ever needs it.
    - If "Out of capacity": retry later, try another availability domain, or upgrade the account to Pay-As-You-Go (still $0 within free limits) which unlocks capacity.
    - Add your SSH public key.
 4. Networking: the default VCN is fine. The bot makes only outbound connections — no ingress rules needed beyond SSH (22).
@@ -51,6 +52,8 @@ automatically at app startup.
 
 ## Ops notes
 
+- Current host: Ampere A1.Flex, 1 OCPU (ARM Neoverse-N1) / 6 GB RAM / 45 GB disk,
+  Ubuntu 24.04, no swap. Public IP is in the `DEPLOY_HOST` repo secret.
 - Logs: `journalctl -u feed1 -f`
 - DB + rotated backups live in `/opt/feed1/.data/` (12-hourly, keeps 20).
 - The whole VM is disposable: a fresh one needs only provision.sh + .env + repo secrets update.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node dist/index.js",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src test",
+    "lint": "eslint src test scripts",
     "test": "vitest run",
     "test:watch": "vitest",
     "smoke": "tsx test/live/smoke.ts",

--- a/scripts/nextVersion.ts
+++ b/scripts/nextVersion.ts
@@ -1,0 +1,55 @@
+// CI-only: computes the next release version from the latest v* tag and the
+// commit that triggered the deploy. Lives outside src/ so it never lands in dist/.
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+export interface NextVersionInput {
+  latestTag: string | null;
+  subject: string;
+  body: string;
+  fallback: string;
+}
+
+// `!` must sit before the colon — `fix: fixed it!` is not a breaking change.
+const BREAKING_SUBJECT = /^[a-z]+(\([^)]*\))?!:/;
+const FEAT_SUBJECT = /^feat(\([^)]*\))?:/;
+const SEMVER = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
+export function bumpKind(subject: string, body: string): 'major' | 'minor' | 'patch' {
+  if (BREAKING_SUBJECT.test(subject) || /BREAKING[ -]CHANGE/.test(body)) return 'major';
+  if (FEAT_SUBJECT.test(subject)) return 'minor';
+  return 'patch';
+}
+
+export function nextVersion({ latestTag, subject, body, fallback }: NextVersionInput): string {
+  if (!latestTag) return fallback;
+
+  const parsed = SEMVER.exec(latestTag);
+  if (!parsed) throw new Error(`latest tag is not a semver version: ${latestTag}`);
+  const [major, minor, patch] = parsed.slice(1, 4).map(Number) as [number, number, number];
+
+  switch (bumpKind(subject, body)) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    default:
+      return `${major}.${minor}.${patch + 1}`;
+  }
+}
+
+function main(): void {
+  const { LATEST_TAG, SUBJECT, BODY, FALLBACK } = process.env;
+  if (!FALLBACK?.trim()) throw new Error('FALLBACK is required');
+  process.stdout.write(
+    nextVersion({
+      latestTag: LATEST_TAG?.trim() ? LATEST_TAG.trim() : null,
+      subject: SUBJECT ?? '',
+      body: BODY ?? '',
+      fallback: FALLBACK.trim(),
+    }),
+  );
+}
+
+const entry = process.argv[1];
+if (entry && resolve(entry) === fileURLToPath(import.meta.url)) main();

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -2,6 +2,7 @@ import { AttachmentBuilder, EmbedBuilder, PermissionFlagsBits } from 'discord.js
 import type { Command } from '../core/command.js';
 import { disableCommand, enableCommand } from '../core/disables.js';
 import { sendable } from '../core/channel.js';
+import { readPackageVersion } from '../core/version.js';
 import { parseLogsArgs, readLogs } from '../ops/logs.js';
 
 const PROTECTED = new Set(['enable', 'disable', 'help']);
@@ -111,6 +112,7 @@ const botinfo: Command = {
       .setTitle('feed1')
       .setDescription('a Last.fm Discord bot')
       .addFields(
+        { name: 'version', value: readPackageVersion(), inline: true },
         { name: 'servers', value: String(client.guilds.cache.size), inline: true },
         { name: 'uptime', value: `${Math.floor(process.uptime() / 60)} min`, inline: true },
         { name: 'commands', value: String(app.registry.all().length), inline: true },

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,13 @@
+import { createRequire } from 'node:module';
+
+// package.json sits outside rootDir, so it can't be imported — and it's two
+// levels up from both src/core/ (dev) and dist/core/ (the deployed tree).
+export function readPackageVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../../package.json') as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/test/commands/admin.test.ts
+++ b/test/commands/admin.test.ts
@@ -3,6 +3,7 @@ import type { EmbedBuilder } from 'discord.js';
 import { adminCommands } from '../../src/commands/admin.js';
 import { fm } from '../../src/commands/fm.js';
 import { Router } from '../../src/core/router.js';
+import { readPackageVersion } from '../../src/core/version.js';
 import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
 
 const byName = (name: string) => adminCommands.find((c) => c.name === name)!;
@@ -66,5 +67,18 @@ describe('&help', () => {
     const embed = fake.embeds[0] as EmbedBuilder;
     expect(embed.data.title).toBe('&fm');
     expect(JSON.stringify(embed.data.fields)).toContain('`f`');
+  });
+});
+
+describe('&botinfo', () => {
+  it('reports the running release version', async () => {
+    const app = appWithAll();
+    const fake = makeFakeMessage({ content: '&botinfo' });
+    await byName('botinfo').run({ app, message: fake.message, args: [] });
+
+    const embed = fake.embeds[0] as EmbedBuilder;
+    const version = embed.data.fields?.find((f) => f.name === 'version');
+    expect(version?.value).toBe(readPackageVersion());
+    expect(version?.value).not.toBe('unknown');
   });
 });

--- a/test/helpers/fake.ts
+++ b/test/helpers/fake.ts
@@ -134,6 +134,9 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
       isSendable: () => true,
     },
     channelId: opts.channelId ?? 'channel-1',
+    client: {
+      guilds: { cache: { size: 1 } },
+    },
     mentions: {
       users: {
         first: () => mentionedUsers[0],

--- a/test/scripts/nextVersion.test.ts
+++ b/test/scripts/nextVersion.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { bumpKind, nextVersion } from '../../scripts/nextVersion.js';
+
+const base = { latestTag: 'v2.0.0', body: '', fallback: '2.0.0' };
+
+describe('bumpKind', () => {
+  it('treats a bang before the colon as breaking', () => {
+    expect(bumpKind('feat(db)!: drop the crowns table', '')).toBe('major');
+    expect(bumpKind('fix!: change the reply shape', '')).toBe('major');
+  });
+
+  it('does not treat a bang elsewhere in the subject as breaking', () => {
+    expect(bumpKind('fix: fixed it!', '')).toBe('patch');
+    expect(bumpKind('feat: now with charts!', '')).toBe('minor');
+  });
+
+  it('honors BREAKING CHANGE in the body regardless of subject', () => {
+    expect(bumpKind('chore: tidy up', 'BREAKING CHANGE: env var renamed')).toBe('major');
+    expect(bumpKind('chore: tidy up', 'BREAKING-CHANGE: env var renamed')).toBe('major');
+  });
+
+  it('maps feat to minor and everything else to patch', () => {
+    expect(bumpKind('feat(fm): show artist ranks (#13)', '')).toBe('minor');
+    expect(bumpKind('fix(fm): shorten the note (#14)', '')).toBe('patch');
+    expect(bumpKind('chore: rename to feed1 (#12)', '')).toBe('patch');
+    expect(bumpKind('docs(deploy): record the VM shape', '')).toBe('patch');
+  });
+
+  it('falls back to patch for non-conventional subjects', () => {
+    expect(bumpKind('wip', '')).toBe('patch');
+    expect(bumpKind('Merge pull request #5 from mxttbennett/beta-branch', '')).toBe('patch');
+    expect(bumpKind('', '')).toBe('patch');
+  });
+});
+
+describe('nextVersion', () => {
+  it('returns the fallback verbatim when no tag exists yet', () => {
+    expect(nextVersion({ ...base, latestTag: null, subject: 'feat: anything' })).toBe('2.0.0');
+  });
+
+  it('bumps patch, minor, and major off the latest tag', () => {
+    expect(nextVersion({ ...base, subject: 'fix(fm): shorten the note (#14)' })).toBe('2.0.1');
+    expect(nextVersion({ ...base, subject: 'feat(fm): show artist ranks (#13)' })).toBe('2.1.0');
+    expect(nextVersion({ ...base, subject: 'feat(db)!: drop a table' })).toBe('3.0.0');
+  });
+
+  it('resets lower components on minor and major bumps', () => {
+    expect(nextVersion({ ...base, latestTag: 'v2.4.7', subject: 'feat: x' })).toBe('2.5.0');
+    expect(nextVersion({ ...base, latestTag: 'v2.4.7', subject: 'feat!: x' })).toBe('3.0.0');
+  });
+
+  it('handles multi-digit components without string sorting artifacts', () => {
+    expect(nextVersion({ ...base, latestTag: 'v2.9.0', subject: 'feat: x' })).toBe('2.10.0');
+    expect(nextVersion({ ...base, latestTag: 'v2.0.9', subject: 'fix: x' })).toBe('2.0.10');
+    expect(nextVersion({ ...base, latestTag: 'v10.0.0', subject: 'fix: x' })).toBe('10.0.1');
+  });
+
+  it('tolerates a missing v prefix', () => {
+    expect(nextVersion({ ...base, latestTag: '2.0.0', subject: 'fix: x' })).toBe('2.0.1');
+  });
+
+  it('rejects a non-semver tag rather than guessing', () => {
+    expect(() => nextVersion({ ...base, latestTag: 'legacy', subject: 'fix: x' })).toThrow(/not a semver/);
+    expect(() => nextVersion({ ...base, latestTag: 'v2.0', subject: 'fix: x' })).toThrow(/not a semver/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "declaration": false,
     "sourceMap": true
   },
-  "include": ["src", "test", "drizzle.config.ts", "eslint.config.js", "vitest.config.ts"]
+  "include": ["src", "test", "scripts", "drizzle.config.ts", "eslint.config.js", "vitest.config.ts"]
 }


### PR DESCRIPTION
## What & why

feed1 had no release history: every merge rsynced a build onto the VM and restarted systemd, leaving no record of what was running or when it shipped — and no foundation for rollback. This makes each merge to `main` mint a semantic version and publish a GitHub Release, so there's a catalogued, browsable history.

The bump is derived from the squash-merge commit subject: `feat(...)` → minor, `<type>!:` or `BREAKING CHANGE` in the body → major, anything else (including non-conventional subjects) → patch. No new dependencies — `scripts/nextVersion.ts` is ~50 lines and unit-tested, and lives outside `src/` so it never ships to the VM.

**Git tags are the source of truth**, not `package.json`. The next version is computed from the highest `v*` tag, so a stale checkout or a skipped write-back can't duplicate or skip a version. Two ordering choices matter:

- The version is stamped and **committed before the deploy**, and the tag targets that commit — so `git checkout v2.0.1` yields the tree that actually shipped. That's the prerequisite for rollback.
- The Release is created **after** `systemctl is-active` passes, so a release never exists for a deploy that didn't come up.

The write-back never rebases. `concurrency` serializes workflow runs but not merges, so if another PR lands mid-deploy, rebasing would publish version A's `package.json` on top of version B's code. Instead it asserts `origin/main == $GITHUB_SHA` and skips with a `::warning::` if `main` moved; tags stay authoritative and the next deploy reconciles.

`package.json` keeps its current `2.0.0`, so the first release is `v2.0.0`. A manual `workflow_dispatch` deploys as-is without minting a version.

Also included: `-botinfo` now reports the running version (with the first unit test for that command), and the deploy docs now record the live VM's actual shape — 1 OCPU / 6 GB, not the "2 OCPU / 12 GB" the README suggested.

## Rollback

Deliberately **not** in this PR — see the follow-up issue. This PR builds the prerequisite (tags whose trees match what was deployed); the follow-up handles the `workflow_dispatch`-a-tag path plus the migration-safety question, since a forward Drizzle migration isn't automatically reversible.

## Testing

- `npm run typecheck`, `npm run lint`, `npx vitest run` — 173 tests pass (11 new for the bump logic, 1 new for `botinfo`).
- Verified `scripts/` does not leak into `dist/` after `npm run build`, so CI code isn't deployed.
- Exercised the CLI by hand for each bump class, including a shell-injection-hostile subject — subject and body are passed via env, never interpolated into the shell.
- Confirmed `git tag -l 'v[0-9]*' --sort=-v:refname` filters out the existing non-semver `legacy` tag and orders multi-digit versions correctly (`v10.0.0` > `v2.10.0` > `v2.9.0`).
- End-to-end release creation is only observable on merge; expect `v2.0.0` with no bump commit (first release is same-version), then `chore(release): v2.0.1 [skip ci]` on the next merge.