### PR TITLE
feat(wk,plays): fall back to the last scrobbled track when nothing is playing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -127,7 +127,7 @@ const plays: Command = {
 
     let artistName = args.join(' ');
     if (!artistName) {
-      const track = await app.lastfm.getNowPlaying(registered.lastfmUsername);
+      const track = await app.lastfm.getLatestTrack(registered.lastfmUsername);
       if (!track) return message.reply(`currently, you are not listening to anything.`);
       artistName = track.artist['#text'];
     }

--- a/src/commands/whoknows.ts
+++ b/src/commands/whoknows.ts
@@ -54,7 +54,7 @@ async function runWhoKnows(ctx: CommandContext, kind: 'artist' | 'album'): Promi
       artistName = joined;
     }
   } else {
-    const track = await app.lastfm.getNowPlaying(registered.lastfmUsername);
+    const track = await app.lastfm.getLatestTrack(registered.lastfmUsername);
     if (!track) return message.reply(app.snippets.notPlaying);
     artistName = track.artist['#text'];
     albumName = kind === 'album' ? track.album['#text'] : undefined;

--- a/src/lastfm/client.ts
+++ b/src/lastfm/client.ts
@@ -91,11 +91,13 @@ export class LastfmClient {
     return this.request('user.getrecenttracks', params);
   }
 
-  /** The currently playing track, or null when nothing is scrobbling right now. */
-  async getNowPlaying(user: string): Promise<RecentTrack | null> {
+  /**
+   * What the user is listening to, falling back to their last scrobble.
+   * Null only when they have never scrobbled anything.
+   */
+  async getLatestTrack(user: string): Promise<RecentTrack | null> {
     const data = await this.getRecentTracks(user, { limit: 1 });
-    const track = data.recenttracks.track[0];
-    return track?.['@attr']?.nowplaying ? track : null;
+    return data.recenttracks.track[0] ?? null;
   }
 
   getTopAlbums(user: string, period: Period, limit = 50, page = 1): Promise<TopAlbums> {

--- a/test/commands/profile.test.ts
+++ b/test/commands/profile.test.ts
@@ -121,6 +121,42 @@ describe('&plays', () => {
     await byName('plays').run({ app, message: fake.message, args: ['nobody'] });
     expect(fake.replies[0]).toBe("you haven't scrobbled `Nobody`.");
   });
+
+  it('resolves the artist from the last scrobble when nothing is playing', async () => {
+    nock(BASE)
+      .get('/2.0/')
+      .query((q) => q.method === 'user.getrecenttracks')
+      .reply(200, {
+        recenttracks: {
+          // no nowplaying attr — this is a finished scrobble
+          track: [{ name: 'Gantz Graf', artist: { '#text': 'Autechre', mbid: '' }, album: { '#text': '', mbid: '' }, image: [], url: '' }],
+          '@attr': { total: '1', user: 'x' },
+        },
+      });
+    nock(BASE)
+      .get('/2.0/')
+      .query((q) => q.method === 'artist.getinfo')
+      .reply(200, {
+        artist: { name: 'Autechre', url: '', stats: { listeners: '1', playcount: '1', userplaycount: '99' }, image: [] },
+      });
+    const app = makeFakeApp(profileCommands);
+    app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'x' }).run();
+    const fake = makeFakeMessage({ content: '&plays' });
+    await byName('plays').run({ app, message: fake.message, args: [] });
+    expect(fake.replies[0]).toBe('you have scrobbled  `Autechre`  **99** times.');
+  });
+
+  it('still reports nothing-playing when the user has never scrobbled', async () => {
+    nock(BASE)
+      .get('/2.0/')
+      .query((q) => q.method === 'user.getrecenttracks')
+      .reply(200, { recenttracks: { track: [], '@attr': { total: '0', user: 'x' } } });
+    const app = makeFakeApp(profileCommands);
+    app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'x' }).run();
+    const fake = makeFakeMessage({ content: '&plays' });
+    await byName('plays').run({ app, message: fake.message, args: [] });
+    expect(fake.replies[0]).toBe('currently, you are not listening to anything.');
+  });
 });
 
 describe('&list', () => {

--- a/test/commands/whoknows.test.ts
+++ b/test/commands/whoknows.test.ts
@@ -32,6 +32,27 @@ function mockArtistScan(plays: Record<string, string>) {
     });
 }
 
+function mockRecentTracks(opts: { nowPlaying?: boolean; empty?: boolean } = {}) {
+  const track = {
+    name: 'Gantz Graf',
+    artist: { '#text': 'Autechre', mbid: '' },
+    album: { '#text': 'Gantz Graf', mbid: '' },
+    image: [],
+    url: '',
+    ...(opts.nowPlaying ? { '@attr': { nowplaying: 'true' } } : {}),
+  };
+  nock(BASE)
+    .persist()
+    .get('/2.0/')
+    .query((q) => q.method === 'user.getrecenttracks')
+    .reply(200, {
+      recenttracks: {
+        track: opts.empty ? [] : [track],
+        '@attr': { total: opts.empty ? '0' : '1', user: 'lfm1' },
+      },
+    });
+}
+
 function guildWithMembers(fake: FakeMessage, ids: string[]) {
   const collection = new Collection(
     ids.map((id) => [id, { user: { id, bot: false, tag: `${id}#0`, username: id } }]),
@@ -102,6 +123,25 @@ describe('&wk', () => {
     const fake = makeFakeMessage({ content: '&wk x' });
     await byName('wk').run({ app, message: fake.message, args: ['x'] });
     expect(fake.replies[0]).toBe(app.snippets.noLogin);
+  });
+
+  it('falls back to the last scrobbled track when nothing is playing', async () => {
+    const { app, fake } = setup({ lfm1: '10', lfm2: '40' });
+    mockRecentTracks({ nowPlaying: false });
+    await byName('wk').run({ app, message: fake.message, args: [] });
+
+    // resolved the artist from the last scrobble instead of bailing out
+    expect(fake.replies).not.toContain(app.snippets.notPlaying);
+    expect((fake.embeds[0] as EmbedBuilder).data.title).toBe('Autechre');
+  });
+
+  it('bails only when the user has never scrobbled anything', async () => {
+    const { app, fake } = setup({ lfm1: '10' });
+    mockRecentTracks({ empty: true });
+    await byName('wk').run({ app, message: fake.message, args: [] });
+
+    expect(fake.replies[0]).toBe(app.snippets.notPlaying);
+    expect(fake.embeds).toHaveLength(0);
   });
 });
 

--- a/test/lastfm/client.test.ts
+++ b/test/lastfm/client.test.ts
@@ -30,21 +30,31 @@ describe('LastfmClient', () => {
     expect(toInt(info.user.playcount)).toBeGreaterThan(100_000);
   });
 
-  it('detects now playing vs last scrobbled', async () => {
+  it('returns the last scrobble when nothing is playing, and the live track when it is', async () => {
     const recent = fixture('user_getrecenttracks');
     nock(BASE).get('/2.0/').query(true).reply(200, recent);
-    const np = await makeClient().getNowPlaying('rj');
-    // recorded fixture has no nowplaying attr — should be null
-    expect(np).toBeNull();
+    // recorded fixture has no nowplaying attr — the last scrobble is still the answer
+    const last = await makeClient().getLatestTrack('rj');
+    expect(last?.name).toBe('Private Idaho');
+    expect(last?.['@attr']?.nowplaying).toBeUndefined();
 
     const withNp = JSON.parse(JSON.stringify(recent)) as {
       recenttracks: { track: Record<string, unknown>[] };
     };
     withNp.recenttracks.track[0]!['@attr'] = { nowplaying: 'true' };
     nock(BASE).get('/2.0/').query(true).reply(200, withNp);
-    const playing = await makeClient().getNowPlaying('rj');
+    const playing = await makeClient().getLatestTrack('rj');
     expect(playing?.name).toBe('Private Idaho');
+    expect(playing?.['@attr']?.nowplaying).toBe('true');
     expect(imageUrl(playing?.image, 2)).toContain('174s');
+  });
+
+  it('returns null only when the user has never scrobbled', async () => {
+    nock(BASE)
+      .get('/2.0/')
+      .query(true)
+      .reply(200, { recenttracks: { track: [], '@attr': { total: '0', user: 'rj' } } });
+    expect(await makeClient().getLatestTrack('rj')).toBeNull();
   });
 
   it('parses top albums/artists/tracks', async () => {


### PR DESCRIPTION
## What & why

`-wk`, `-a` and `-plays` all bailed with "not listening to anything" the moment Last.fm reported no live track — even though the user obviously had scrobbles worth checking. `-fm`/`-f` have always fallen back to the last scrobble; these three now behave the same way.

`-a` is the album who-knows and shares `runWhoKnows` with `-wk`, so both came from one call site (`whoknows.ts:57`). `-p` is an alias of `-plays`, not a separate command, so that's one more (`profile.ts:130`).

## How

`LastfmClient.getNowPlaying` — which returned `null` unless the `nowplaying` attr was set — is replaced by `getLatestTrack`, returning the live track or the most recent scrobble, and `null` only when the user has never scrobbled at all. All three call sites switch to it, so the not-playing replies now fire *only* in that genuinely-empty case. That's the same semantics `-fm` already had at `fm.ts:132`. `getNowPlaying` had no remaining callers, so it's gone.

The fallback is silent by design — no change to the `checking who knows...` line or the result footer.

## Testing

`npm run typecheck`, `npm run lint`, `npm test` (178 passing). New coverage at both levels: the client returning last-scrobble vs live track vs null-when-never-scrobbled, plus `-wk` and `-plays` resolving from a finished scrobble and still bailing when there's nothing at all. Mutation-checked — restoring the old nowplaying-only behavior fails exactly those three tests.

## Not changed

`-a` with no args still resolves the album from the resolved track, so a last scrobble with no album data hits the existing `I couldn't work out which album to check.` (`whoknows.ts:63`). Left alone; say the word if you want that path to explain itself.