### PR TITLE
docs: add VERSIONING.md as the single source of truth for version bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,8 @@ a fake `Message` recording replies/embeds/edits). No network in tests.
 
 Merging to `main` triggers `.github/workflows/deploy.yml`: tests + build, rsync to an Oracle Cloud
 VM, DB backup, `systemctl restart feed1`. CI (typecheck, lint, test, build) runs on every PR.
+
+**Every PR merged to `main` must bump `version` in `package.json`** — docs and CI-only changes
+included, as a patch. The merge tags that version and cuts a release; an unchanged version leaves
+the deploy fine but turns the run red. Read [VERSIONING.md](VERSIONING.md) before choosing the
+number; it owns the rules, and `deploy/README.md` covers rollback mechanics.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ npm run dev
 
 GitHub Actions deploys `main` to an Oracle Cloud free-tier VM over SSH. Bump `version` in
 `package.json` as part of your PR; each merge tags that version and publishes a
-[GitHub Release](../../releases).
-See [deploy/README.md](deploy/README.md) for the one-time setup and the versioning rules.
+[GitHub Release](../../releases). Every merge bumps — see [VERSIONING.md](VERSIONING.md) for which
+number and why, and [deploy/README.md](deploy/README.md) for the one-time setup and rollbacks.
 
 ## Commands
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,63 @@
+# Versioning
+
+`package.json`'s `version` is the source of truth. You bump it by hand, in the PR that makes the
+change. Nothing is inferred from commit messages, and CI never writes to the repo — the version
+that ships is the one you reviewed.
+
+On merge to `main`, the deploy workflow ships the build and then cuts an annotated tag
+`v<version>` plus a matching [GitHub Release](../../releases) with generated notes.
+
+## Which number to bump
+
+| Bump | When | Examples |
+|---|---|---|
+| **major** | A generational rewrite, a large addition or refactor, or a breaking change of medium-or-higher scale | The 2.0 TypeScript rewrite; removing or renaming a command people use; a deploy that needs manual DB or `.env` work |
+| **minor** | New user-visible behaviour, or a self-contained new command | Artist ranks in `-fm`; `-wk`/`-a`/`-plays` falling back to the last scrobble |
+| **patch** | Everything else | Bug fixes, copy tweaks, refactors with no visible change, docs, CI, tests |
+
+"Breaking" is about the people using the bot, not internal shape: renaming an exported function is
+a patch, renaming `-wk` is not.
+
+## Every merge to `main` bumps
+
+Including docs-only and CI-only PRs — those take a patch. Two reasons: the release step **fails on
+a tag that already exists**, so a merge without a bump turns `main` red; and one release per merge
+keeps releases and merge commits one-to-one, which is what makes `-botinfo` a useful answer to
+"what's actually running?".
+
+Put the bump in its own final commit so it's easy to see and easy to redo after a rebase:
+
+```sh
+npm version 2.3.0 --no-git-tag-version   # updates package.json + package-lock.json
+git commit -am "chore(release): 2.3.0"
+```
+
+**Two open PRs both bumping to the same number will conflict** on that line — whichever merges
+second needs a rebase and a re-bump. For stacked work, branch the second PR off the first and
+bump past it rather than off `main`.
+
+## What CI does with it
+
+The release is the **last** step, after `systemctl is-active` passes, so a version mistake can
+never block shipping. If the version is malformed, already tagged (you forgot to bump), or lower
+than the latest release, **the deploy still succeeds and the run goes red** with the reason. Fix it
+by bumping in the next PR, or tag that commit by hand.
+
+- Which version is live: `-botinfo` in Discord, or
+  `node -p "require('/opt/feed1/package.json').version"` on the box.
+- A manual `workflow_dispatch` run with no inputs deploys the checked-out tree as-is — no tag, no
+  release.
+
+## Versions as rollback targets
+
+Every release tag is a deployable point in time: `gh workflow run deploy.yml -f tag=v2.1.0` puts
+that tree on the box, and because the tag carries its own `package.json`, the bot reports the
+version you rolled back to. Rolling back creates no tag and no release, and changes nothing about
+sequencing — the next merge still releases whatever `main` says.
+
+This is the practical reason patch bumps are cheap and worth spending: the more granular the
+releases, the finer-grained the rollback. The limit is the database — Drizzle is forward-only, so
+rolling back past a migration is refused unless forced. A change that adds a migration is a
+rollback boundary, which is worth keeping in mind when deciding how much to put in one PR.
+
+Mechanics, the migration guard, and DB restores: [deploy/README.md](deploy/README.md).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,21 +47,12 @@ automatically at app startup.
 
 ## Versioning & releases
 
-**`package.json`'s `version` is the source of truth — bump it yourself in the PR.** On merge to
-`main`, CI tags whatever it finds there and cuts a matching GitHub Release. Nothing is inferred
-from commit messages and CI never writes to the repo, so the version that ships is exactly the
-one you reviewed.
+Which number to bump, when to bump it, and what CI does with it: **[VERSIONING.md](../VERSIONING.md)**.
 
-Pick the bump the usual way: breaking → major, new behaviour → minor, otherwise patch.
-
-The release is created only after `systemctl is-active` passes, and it's the **last** step — so
-a version mistake never blocks shipping. If the version is malformed, already tagged (you forgot
-to bump), or lower than the latest release, **the deploy still succeeds and the run goes red**
-with the reason. Fix it by bumping in your next PR, or tag that commit by hand.
-
-- Which version is live: `node -p "require('/opt/feed1/package.json').version"`, or `-botinfo` in Discord.
-- A manual `workflow_dispatch` run deploys the checked-out tree as-is — no tag, no release.
-  Pass a `tag` input to roll back to a release; see [Rolling back](#rolling-back).
+The short version: `package.json`'s `version` is the source of truth, you bump it in the PR, and
+each merge to `main` tags it and cuts a GitHub Release as the last step of this workflow — so a
+version mistake never blocks shipping. A manual `workflow_dispatch` run deploys the checked-out
+tree as-is with no tag and no release; pass a `tag` input to roll back to a release, below.
 
 ## Rolling back
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What & why

The release *mechanics* were already documented in `deploy/README.md`, but the *policy* wasn't written down anywhere — what counts as major vs minor vs patch for this bot, and the non-obvious rule that **every** merge to `main` has to bump because the release step fails on an existing tag. `VERSIONING.md` now owns that.

Policy as agreed:

| Bump | When |
|---|---|
| major | generational rewrite, large addition/refactor, or a breaking change of medium-or-higher scale |
| minor | new user-visible behaviour or a self-contained new command |
| patch | everything else — fixes, copy, refactors, docs, CI, tests |

"Breaking" is scoped to people using the bot, not internal shape: renaming an exported function is a patch, renaming `-wk` isn't.

Also documented: the bump goes in its own final commit (`npm version --no-git-tag-version`); two open PRs bumping to the same number conflict on that line, so stacked work should branch off the first PR and bump past it; and release granularity is what makes rollback granular, with migrations as the hard boundary.

## Doc ownership

To avoid two sources of truth, the versioning section of `deploy/README.md` is trimmed to a short summary plus a pointer. It keeps what's genuinely ops: rollback, the migration guard, DB restores. `README.md` and `CLAUDE.md` point at `VERSIONING.md` too.

## Note on the base branch

Stacked on `matt/wk-plays-last-scrobble` (#19) rather than `main`, because both PRs bump `version` and would otherwise conflict on that line. #19 bumps to `2.2.0`, this one to `2.2.1`. **Merge #19 first** — GitHub will retarget this to `main` automatically.