### PR TITLE
chore(claude): pin commit/PR attribution off at the repo level

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What & why

Declares `attribution: { commit: "", pr: "" }` in project settings so suppressing the `Co-Authored-By` trailer no longer depends on whoever's machine is running Claude.

This is belt-and-braces — your global `~/.claude/settings.json` already sets exactly this, and empirically no commit since #12 has carried a trailer. But the history was just rewritten specifically to remove those trailers, so it's worth making the guarantee travel with the repo rather than being inherited.

Version bumped to `2.2.1` because `v2.2.0` is already released; without it the deploy would ship fine but the release step would go red on a duplicate tag.

## Testing

- `jq` confirms the file is valid JSON and that `attribution.commit` / `attribution.pr` are both empty strings, byte-identical to the global block.
- 178 tests pass.
- This PR's own commit carries **no** `Co-Authored-By` trailer — the setting demonstrating itself.