### PR TITLE
feat(fm): settle the album crown inline so the footer gif stops guessing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,10 @@ tested without Discord or HTTP.
   Edits that only *add* optional detail should swallow their failures so a hiccup can't discard an
   already-good message.
 - Numbers arrive from Last.fm as strings — parse with `toInt()` from `src/lastfm/types.ts`.
-- Background work (crown recalculation) is queued to the DB and drained by a worker, not done inline.
+- Artist crown recalculation is queued to the DB and drained by a worker, not done inline. The
+  **album** crown is the exception: `-fm` settles it inline after its rank scans, because the footer
+  gif has to say whether the caller holds the crown. The queued album job is enqueued first as the
+  failure path and deleted once the inline scan succeeds.
 
 ## Loop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/fm.ts
+++ b/src/commands/fm.ts
@@ -2,9 +2,13 @@ import { EmbedBuilder } from 'discord.js';
 import type { Message } from 'discord.js';
 import { and, eq } from 'drizzle-orm';
 import type { Command, AppContext } from '../core/command.js';
+import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
 import { getRegisteredUser } from '../core/users.js';
 import { sendable } from '../core/channel.js';
+import { gatherRegisteredMembers } from '../crowns/members.js';
+import { notifyCrownChange } from '../crowns/notify.js';
+import { CrownService } from '../crowns/service.js';
 import { enqueueCrownJob } from '../crowns/worker.js';
 import { imageUrl, toInt } from '../lastfm/types.js';
 import type { Period, RecentTrack } from '../lastfm/types.js';
@@ -96,6 +100,29 @@ function findAlbumRank(
   });
 }
 
+/** The footer gif for a settled album crown, or null when the guild has no crown for it yet. */
+function albumCrownGif(
+  db: Db,
+  guildId: string,
+  artistName: string,
+  albumName: string,
+  authorId: string,
+): string | null {
+  const crown = db
+    .select()
+    .from(schema.albumCrowns)
+    .where(
+      and(
+        eq(schema.albumCrowns.guildId, guildId),
+        eq(schema.albumCrowns.artistName, artistName),
+        eq(schema.albumCrowns.albumName, albumName),
+      ),
+    )
+    .get();
+  if (!crown) return null;
+  return crown.userId === authorId ? CROWN_GIF_OWN : CROWN_GIF_OTHER;
+}
+
 function baseEmbed(message: Message, lastfmUser: string, track: RecentTrack): EmbedBuilder {
   const artist = track.artist['#text'];
   const album = track.album['#text'];
@@ -159,6 +186,9 @@ export const fm: Command = {
       let canonicalArtist = artist;
       let canonicalAlbum = album;
       let crownGif = CROWN_GIF_DEFAULT;
+      // non-null only once Last.fm has told us the album exists, which gates the inline crown scan
+      let crownArtist: string | null = null;
+      let crownAlbum: string | null = null;
 
       try {
         const artistData = await app.lastfm.getArtistInfo(artist, lastfmUser);
@@ -174,20 +204,16 @@ export const fm: Command = {
           albumPlays = toInt(albumData.album.userplaycount);
           canonicalAlbum = albumData.album.name;
 
-          const crown = app.db
-            .select()
-            .from(schema.albumCrowns)
-            .where(
-              and(
-                eq(schema.albumCrowns.guildId, message.guild!.id),
-                eq(schema.albumCrowns.artistName, albumData.album.artist),
-                eq(schema.albumCrowns.albumName, albumData.album.name),
-              ),
-            )
-            .get();
-          if (crown) {
-            crownGif = crown.userId === message.author.id ? CROWN_GIF_OWN : CROWN_GIF_OTHER;
-          }
+          crownArtist = albumData.album.artist;
+          crownAlbum = albumData.album.name;
+          crownGif =
+            albumCrownGif(
+              app.db,
+              message.guild!.id,
+              crownArtist,
+              crownAlbum,
+              message.author.id,
+            ) ?? CROWN_GIF_DEFAULT;
         } catch {
           // no album info → no album segment, default gif
         }
@@ -253,6 +279,63 @@ export const fm: Command = {
         await collect(albumRanks, ALBUM_RANK_PAGES, (period, pages) =>
           findAlbumRank(app, lastfmUser, period, pages, canonicalArtist, canonicalAlbum),
         );
+      }
+
+      // phase 3: legacy's inline album crown check, so CROWN_GIF_DEFAULT is a placeholder rather
+      // than a permanent answer. Its own try/catch — a failed scan must not discard the footer we
+      // already painted, and the queued album job is the retry path.
+      if (crownArtist && crownAlbum) {
+        try {
+          const guild = message.guild!;
+          const members = await gatherRegisteredMembers(app.db, guild);
+          if (members.length > 0) {
+            const service = new CrownService(app.db, app.lastfm, app.guildScanLock, (change) =>
+              // the DM is incidental here; losing it must not cost us the icon repaint
+              notifyCrownChange(message.client, app.db, change).catch(() => undefined),
+            );
+            const result = await app.guildScanLock.run(`scan:${guild.id}`, () =>
+              service.scan(
+                {
+                  guildId: guild.id,
+                  guildName: guild.name,
+                  artistName: crownArtist,
+                  albumName: crownAlbum,
+                },
+                members,
+              ),
+            );
+
+            // settled inline, so the queued duplicate is waste. Claimed jobs are left for the
+            // worker, whose requeue-by-id would otherwise become a silent no-op.
+            app.db
+              .delete(schema.crownJobs)
+              .where(
+                and(
+                  eq(schema.crownJobs.kind, 'album'),
+                  eq(schema.crownJobs.status, 'pending'),
+                  eq(schema.crownJobs.guildId, guild.id),
+                  eq(schema.crownJobs.artistName, canonicalArtist),
+                  eq(schema.crownJobs.albumName, canonicalAlbum),
+                ),
+              )
+              .run();
+
+            // the scan's own canonical names, which need not match the ones we read with above
+            const settled = albumCrownGif(
+              app.db,
+              guild.id,
+              result.artistName,
+              result.albumName ?? crownAlbum,
+              message.author.id,
+            );
+            if (settled && settled !== crownGif) {
+              crownGif = settled;
+              await repaint();
+            }
+          }
+        } catch {
+          // the queued album job is the fallback, and reports its own failures after retrying
+        }
       }
     } catch (error) {
       await app.errors.report(error, 'fm enrichment');

--- a/test/commands/fm.test.ts
+++ b/test/commands/fm.test.ts
@@ -3,8 +3,14 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { EmbedBuilder } from 'discord.js';
 import { fm } from '../../src/commands/fm.js';
 import { schema } from '../../src/db/index.js';
-import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
-import { LOADING_GIF, CROWN_GIF_OWN, NOT_PLAYING_NOTE } from '../../src/commands/fmFormat.js';
+import { makeFakeApp, makeFakeMessage, withGuildMembers } from '../helpers/fake.js';
+import {
+  LOADING_GIF,
+  CROWN_GIF_DEFAULT,
+  CROWN_GIF_OTHER,
+  CROWN_GIF_OWN,
+  NOT_PLAYING_NOTE,
+} from '../../src/commands/fmFormat.js';
 
 const BASE = 'https://ws.audioscrobbler.com';
 
@@ -44,8 +50,12 @@ interface MockOptions {
   album?: string;
   artistPlays?: string;
   albumPlays?: number;
+  /** per-last.fm-username album plays for the crown fan-out; others get `albumPlays` */
+  albumPlaysByUser?: Record<string, number>;
   /** make user.gettopartists fail so only album ranks can resolve */
   topArtistsDown?: boolean;
+  /** make album.getinfo fail for everyone but the caller, sinking the crown scan */
+  albumScanDown?: boolean;
 }
 
 function mockLastfm(opts: MockOptions = {}) {
@@ -54,7 +64,9 @@ function mockLastfm(opts: MockOptions = {}) {
     album = 'Gantz Graf',
     artistPlays = '250',
     albumPlays = 42,
+    albumPlaysByUser = {},
     topArtistsDown = false,
+    albumScanDown = false,
   } = opts;
 
   nock(BASE)
@@ -79,12 +91,27 @@ function mockLastfm(opts: MockOptions = {}) {
         image: [],
       },
     });
+  // one username-aware interceptor: nock matches in registration order, so a second
+  // album.getinfo mock added by a test would never be reached
   nock(BASE)
     .persist()
     .get('/2.0/')
     .query((q) => q.method === 'album.getinfo')
-    .reply(200, {
-      album: { name: 'Gantz Graf', artist: 'Autechre', url: '', userplaycount: albumPlays, image: [] },
+    .reply((uri) => {
+      const username = new URL(`https://x${uri}`).searchParams.get('username') ?? '';
+      if (albumScanDown && username !== 'lfm1') return [500, {}];
+      return [
+        200,
+        {
+          album: {
+            name: 'Gantz Graf',
+            artist: 'Autechre',
+            url: '',
+            userplaycount: albumPlaysByUser[username] ?? albumPlays,
+            image: [],
+          },
+        },
+      ];
     });
   nock(BASE)
     .persist()
@@ -213,7 +240,7 @@ describe('&fm', () => {
     expect(app.reportedErrors).toHaveLength(0);
   });
 
-  it('enqueues artist and album crown jobs instead of scanning inline', async () => {
+  it('enqueues artist and album crown jobs before rendering', async () => {
     mockLastfm();
     const app = setup();
     const fake = makeFakeMessage({ content: '&fm' });
@@ -286,5 +313,165 @@ describe('&fm', () => {
 
     expect((fake.embeds[0] as EmbedBuilder).data.footer?.text).toBe('loading your data...');
     expect(lastFooter(fake.edits)).not.toContain(NOT_PLAYING_NOTE);
+  });
+});
+
+describe('&fm inline album crown', () => {
+  /** the caller plus one rival, both registered so the member join keeps them */
+  function setupWithMembers(opts: { fetchUser?: (id: string) => Promise<unknown> } = {}) {
+    const app = makeFakeApp([fm]);
+    app.db
+      .insert(schema.users)
+      .values([
+        { discordUserId: 'user-1', lastfmUsername: 'lfm1' },
+        { discordUserId: 'user-2', lastfmUsername: 'lfm2' },
+      ])
+      .run();
+    const fake = makeFakeMessage({ content: '&fm', ...opts });
+    withGuildMembers(fake, ['user-1', 'user-2']);
+    return { app, fake };
+  }
+
+  function lastIcon(edits: unknown[]): string {
+    return footerIconOf(edits[edits.length - 1]);
+  }
+
+  function insertCrown(app: ReturnType<typeof makeFakeApp>, userId: string, albumPlays: number) {
+    app.db
+      .insert(schema.albumCrowns)
+      .values({
+        guildId: 'guild-1',
+        userId,
+        artistName: 'Autechre',
+        albumName: 'Gantz Graf',
+        albumPlays,
+      })
+      .run();
+  }
+
+  it('replaces the placeholder gif with the own-crown gif once the scan settles', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 5 } });
+    const { app, fake } = setupWithMembers();
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(footerIconOf(fake.edits[0])).toBe(CROWN_GIF_DEFAULT);
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_OWN);
+    // the footer text survives the repaint untouched
+    expect(lastFooter(fake.edits)).toBe(SCROBBLES + ARTIST_RANKS + ALBUM_RANKS);
+
+    const crown = app.db.select().from(schema.albumCrowns).all()[0]!;
+    expect(crown.userId).toBe('user-1');
+    expect(crown.albumPlays).toBe(42);
+  });
+
+  it('shows the other-crown gif when another member holds the album', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 500 } });
+    const { app, fake } = setupWithMembers();
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(footerIconOf(fake.edits[0])).toBe(CROWN_GIF_DEFAULT);
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_OTHER);
+    expect(app.db.select().from(schema.albumCrowns).all()[0]!.userId).toBe('user-2');
+  });
+
+  it('spends no extra edit when the scan confirms the gif already shown', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 5 } });
+    const { app, fake } = setupWithMembers();
+    insertCrown(app, 'user-1', 42);
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(footerIconOf(fake.edits[0])).toBe(CROWN_GIF_OWN);
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_OWN);
+    // same count as a run with no crown scan at all — the change guard held
+    expect(fake.edits).toHaveLength(9);
+  });
+
+  it('drops the redundant album job but leaves the artist job queued', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 5 } });
+    const { app, fake } = setupWithMembers();
+    await fm.run({ app, message: fake.message, args: [] });
+
+    const jobs = app.db.select().from(schema.crownJobs).all();
+    expect(jobs.map((j) => j.kind)).toEqual(['artist']);
+  });
+
+  it('keeps the finished footer when the crown fan-out fails', async () => {
+    mockLastfm({ albumScanDown: true });
+    const { app, fake } = setupWithMembers();
+    await fm.run({ app, message: fake.message, args: [] });
+
+    const footer = lastFooter(fake.edits);
+    expect(footer).toBe(SCROBBLES + ARTIST_RANKS + ALBUM_RANKS);
+    expect(footer).not.toContain('could not load your data.');
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_DEFAULT);
+    // both jobs survive, so the worker still gets to settle the crown
+    expect(app.db.select().from(schema.crownJobs).all()).toHaveLength(2);
+    expect(app.reportedErrors).toHaveLength(0);
+  });
+
+  it('notifies both sides when the caller takes the crown, and still repaints', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 5 } });
+    const dms: string[] = [];
+    const { app, fake } = setupWithMembers({
+      fetchUser: (id) =>
+        Promise.resolve({
+          tag: `${id}#0`,
+          send: (text: string) => {
+            dms.push(`${id}: ${text}`);
+            return Promise.resolve();
+          },
+        }),
+    });
+    insertCrown(app, 'user-2', 5);
+    app.db
+      .insert(schema.notifPrefs)
+      .values([
+        { userId: 'user-1', onWin: true },
+        { userId: 'user-2', onLoss: true },
+      ])
+      .run();
+
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(dms.some((d) => d.startsWith('user-1:') && d.includes('have won'))).toBe(true);
+    expect(dms.some((d) => d.startsWith('user-2:') && d.includes('have lost'))).toBe(true);
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_OWN);
+  });
+
+  it('still repaints when the notification path throws', async () => {
+    mockLastfm({ albumPlaysByUser: { lfm2: 5 } });
+    const { app, fake } = setupWithMembers({
+      fetchUser: () => {
+        throw new Error('users unavailable');
+      },
+    });
+    insertCrown(app, 'user-2', 5);
+
+    await fm.run({ app, message: fake.message, args: [] });
+
+    // the DM throw is swallowed, so the caller's takeover still reaches the footer
+    expect(footerIconOf(fake.edits[0])).toBe(CROWN_GIF_OTHER);
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_OWN);
+    expect(app.db.select().from(schema.albumCrowns).all()[0]!.userId).toBe('user-1');
+  });
+
+  it('skips the scan for a scrobble with no album', async () => {
+    mockLastfm({ album: '' });
+    const { app, fake } = setupWithMembers();
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_DEFAULT);
+    expect(app.db.select().from(schema.albumCrowns).all()).toHaveLength(0);
+  });
+
+  it('skips the scan when nobody in the guild is registered', async () => {
+    mockLastfm();
+    const app = setup();
+    const fake = makeFakeMessage({ content: '&fm' });
+    await fm.run({ app, message: fake.message, args: [] });
+
+    expect(lastIcon(fake.edits)).toBe(CROWN_GIF_DEFAULT);
+    expect(app.db.select().from(schema.albumCrowns).all()).toHaveLength(0);
+    expect(app.db.select().from(schema.crownJobs).all()).toHaveLength(2);
   });
 });

--- a/test/commands/whoknows.test.ts
+++ b/test/commands/whoknows.test.ts
@@ -3,8 +3,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { EmbedBuilder } from 'discord.js';
 import { whoKnowsCommands } from '../../src/commands/whoknows.js';
 import { schema } from '../../src/db/index.js';
-import { makeFakeApp, makeFakeMessage, type FakeMessage } from '../helpers/fake.js';
-import { Collection } from 'discord.js';
+import { makeFakeApp, makeFakeMessage, withGuildMembers } from '../helpers/fake.js';
 import type { Message } from 'discord.js';
 
 const BASE = 'https://ws.audioscrobbler.com';
@@ -53,30 +52,6 @@ function mockRecentTracks(opts: { nowPlaying?: boolean; empty?: boolean } = {}) 
     });
 }
 
-function guildWithMembers(fake: FakeMessage, ids: string[]) {
-  const collection = new Collection(
-    ids.map((id) => [id, { user: { id, bot: false, tag: `${id}#0`, username: id } }]),
-  );
-  const cache = new Collection<string, unknown>();
-  const members = {
-    cache,
-    fetch: () => {
-      for (const [id, m] of collection) cache.set(id, m);
-      return Promise.resolve(collection);
-    },
-  };
-  (
-    fake.message as unknown as {
-      guild: { id: string; name: string; members: unknown; memberCount: number };
-    }
-  ).guild = {
-    id: 'guild-1',
-    name: 'Test Guild',
-    members,
-    memberCount: ids.length,
-  };
-}
-
 function setup(plays: Record<string, string>) {
   const app = makeFakeApp(whoKnowsCommands);
   app.db
@@ -88,7 +63,7 @@ function setup(plays: Record<string, string>) {
     .run();
   mockArtistScan(plays);
   const fake = makeFakeMessage({ content: '&wk autechre' });
-  guildWithMembers(fake, ['user-1', 'user-2']);
+  withGuildMembers(fake, ['user-1', 'user-2']);
   return { app, fake };
 }
 
@@ -171,7 +146,7 @@ describe('&a', () => {
       });
 
     const fake = makeFakeMessage({ content: '&a Autechre | Confield' });
-    guildWithMembers(fake, ['user-1']);
+    withGuildMembers(fake, ['user-1']);
     await byName('a').run({ app, message: fake.message, args: ['Autechre', '|', 'Confield'] });
 
     const embed = fake.embeds[0] as EmbedBuilder;

--- a/test/helpers/fake.ts
+++ b/test/helpers/fake.ts
@@ -1,3 +1,4 @@
+import { Collection } from 'discord.js';
 import type { Message } from 'discord.js';
 import type { AppContext, Command } from '../../src/core/command.js';
 import { CommandRegistry } from '../../src/core/command.js';
@@ -55,6 +56,8 @@ export interface FakeMessageOptions {
   memberDisplayColor?: number;
   /** 0-indexed edit calls that should reject, to exercise non-fatal edit paths */
   failEditsAt?: number[];
+  /** stands in for `client.users.fetch`, for the crown-notification DM path */
+  fetchUser?: (id: string) => Promise<unknown>;
 }
 
 export interface FakeMessage {
@@ -124,7 +127,11 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
       ? {
           id: guildId,
           name: `guild-${guildId}`,
-          members: { fetch: () => Promise.resolve(new Map()) },
+          memberCount: 0,
+          members: {
+            cache: new Collection<string, unknown>(),
+            fetch: () => Promise.resolve(new Collection<string, unknown>()),
+          },
         }
       : null,
     channel: {
@@ -136,6 +143,7 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
     channelId: opts.channelId ?? 'channel-1',
     client: {
       guilds: { cache: { size: 1 } },
+      users: { fetch: opts.fetchUser ?? (() => Promise.resolve(null)) },
     },
     mentions: {
       users: {
@@ -147,4 +155,32 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
   } as unknown as Message;
 
   return { replies, embeds, edits, message };
+}
+
+/**
+ * Give a fake message a guild populated with the given member ids. `fetch()` fills the cache
+ * lazily, so `gatherRegisteredMembers` exercises its cache-miss branch. Ids still need matching
+ * `users` rows to survive the join in `gatherRegisteredMembers`.
+ */
+export function withGuildMembers(fake: FakeMessage, ids: string[]): void {
+  const all = new Collection<string, unknown>(
+    ids.map((id) => [id, { user: { id, bot: false, tag: `${id}#0`, username: id } }]),
+  );
+  const cache = new Collection<string, unknown>();
+  (
+    fake.message as unknown as {
+      guild: { id: string; name: string; members: unknown; memberCount: number };
+    }
+  ).guild = {
+    id: 'guild-1',
+    name: 'Test Guild',
+    memberCount: ids.length,
+    members: {
+      cache,
+      fetch: () => {
+        for (const [id, m] of all) cache.set(id, m);
+        return Promise.resolve(all);
+      },
+    },
+  };
 }


### PR DESCRIPTION
## What & why

`-f`/`-fm` picks its footer icon from three GIFs: `CROWN_GIF_OWN` when the caller holds the album crown, `CROWN_GIF_OTHER` when someone else does, `CROWN_GIF_DEFAULT` when the holder is unknown. DEFAULT is meant to be a *placeholder*, replaced once a full album crown check settles — that's what the old bot did. The 2.0 rewrite kept the up-front crown read but swapped legacy's inline scan for a queued background job, and never added anything to flip the icon afterwards, so DEFAULT was permanent for the life of the message.

This restores the legacy shape. `legacy:src/commands/fm.js` read `ACrowns` up front and saved the result as `orig_fimg` (`:54-88`), ran a full album crown fan-out after its rank scans (`:688-905`), then re-read the row and re-edited the embed **only if the gif changed** (`:906-955`). Same three steps here, reusing `CrownService` instead of writing a second fan-out.

Two guards carry most of the correctness:

- **The scan gets its own swallowing `try`/`catch`.** Inside the existing outer `try`, a retryable `LastfmError` from the fan-out would land in the enrichment handler and replace a complete footer with `could not load your data.` — the opposite of the "edits that only *add* optional detail should swallow their failures" rule in `CLAUDE.md`. The catch stays silent rather than reporting: a transient blip on the highest-traffic command would spam the error channel, and the queued job already retries and reports through the worker.
- **The queued album job is the failure path.** Still enqueued before any rendering, so its existing invariant holds, and deleted only after the inline scan succeeds — scoped to `status = 'pending'`, since deleting a job the worker has already claimed would make its requeue-by-id a silent no-op.

The post-scan read keys off `ScanResult.artistName`/`albumName` rather than the pre-scan key, because `CrownService` reassigns the canonical names on every member iteration (`service.ts:92-93`), so the written key comes from the last successfully scanned member and need not match what we read with. The change-guard compares GIF constants, not keys, so it stays correct either way.

`notifyCrownChange` is now wrapped in a `.catch` — `service.ts:135` awaits `onChange` unguarded, and a DM hiccup must not cost the icon repaint.

**Accepted cost:** `-f` gains one `album.getInfo` per registered member through the shared 250 ms rate limiter (+~7.5 s in a 30-member guild) and serialises against other guild scans on `scan:${guildId}`. Nothing user-visible is blocked by it — the footer text is complete before the scan starts; only the icon flip is delayed. `-fm` is documented as the exception to the background-work rule in `CLAUDE.md`.

## Testing

`npm test` (187 pass), `lint`, `typecheck` and `build` all green. Nine new cases in `&fm inline album crown`: the DEFAULT → OWN and DEFAULT → OTHER repaints, no extra edit when the scan confirms the gif already shown, the album job dropped while the artist job survives, the footer surviving a failed fan-out, crown-transfer DMs firing from `-f`, the repaint surviving a throwing DM path, and the two skip paths (no album, no registered members).

Each of the three guards was mutation-checked — removing the notification swallow, the change guard, or the dedicated catch each fails exactly the test written to protect it.

Test-fake changes worth a look: the shared fake guild now presents a `Collection`-backed member cache and `memberCount` (it previously had `members.fetch` but no `cache`, which would have thrown a `TypeError` inside `gatherRegisteredMembers` — silently swallowed, so the new path would never have been exercised), and `whoknows.test.ts`'s local `guildWithMembers` is promoted to a shared `withGuildMembers` helper rather than copied.

## Out of scope

- Artist crowns influencing the footer icon — legacy never did this, and it would double the scan cost.
- `CrownJobWorker.processJob` not taking the outer `scan:${guildId}` lock (`worker.ts:149-162`), so a worker job and an inline `-f` scan can fan out over the same album concurrently. The inner per-artist lock keeps the write consistent, so the cost is wasted API calls, not corruption. Pre-existing for `-a`; this change makes it more likely. Worth a follow-up.
- The `crown_jobs` artist-name key skew at `fm.ts:210` (album jobs are enqueued with the `artist.getInfo`-derived name); the delete deliberately matches the enqueued values so it targets the right row.
- The unconditional `CROWN_GIF_OWN` author icon in `whoknows.ts:110`, which ignores who actually holds the crown.