### PR TITLE
feat(ops): pull a read-only prod DB snapshot for local querying

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ LASTFM_API_KEY=
 # Database
 DB_PATH=.data/feed1.sqlite
 
+# Optional: prod host for `npm run db:pull` (user@host; bare host assumes ubuntu@)
+PROD_SSH_HOST=
+
 # Optional: comma-separated guildId:pageCap overrides for chart queue depth
 # e.g. 671074176622264320:0 means unlimited pages for that guild
 CHART_QUEUE_PAGE_OVERRIDES=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ tested without Discord or HTTP.
 npm run dev        # tsx watch against the dev bot
 npm test           # vitest
 npm run typecheck  # tsc --noEmit
-npm run lint       # eslint src test
+npm run lint       # eslint src test scripts
 npm run smoke      # drives a running dev bot over real Discord
+npm run db:pull    # read-only prod snapshot -> .data/prod/ (see deploy/README.md)
 ```
 
 Tests use `nock` with net access disabled and the fakes in `test/helpers/fake.ts` (in-memory SQLite,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -103,6 +103,22 @@ sudo systemctl start feed1
 Restoring discards everything scrobbled since that snapshot, which is why rollback never does it
 automatically.
 
+### Querying prod data locally
+
+```sh
+npm run db:pull                        # host from PROD_SSH_HOST in .env
+npm run db:pull -- ubuntu@<vm-ip>      # or pass it
+```
+
+Lands a snapshot at `.data/prod/feed1-prod.sqlite` (gitignored) for TablePlus, `sqlite3`, or
+anything else. It's a point-in-time copy — re-run it for fresh data.
+
+Never point a client at the live `.data/feed1.sqlite`, over sshfs or otherwise: GUI clients open
+SQLite read-write, and WAL locking across a network filesystem is the documented way to corrupt a
+database. The pull instead opens prod **read-only** on the box and uses `VACUUM INTO`, which is
+safe against the running bot and physically cannot write to it; what comes down is a standalone
+file with no WAL.
+
 ## Discord portal checklist (once per bot application)
 
 - Bot → Privileged Gateway Intents: enable **Server Members Intent** and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "vitest",
     "smoke": "tsx test/live/smoke.ts",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:pull": "bash scripts/db-pull.sh"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/db-pull.sh
+++ b/scripts/db-pull.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Pull a point-in-time snapshot of the production database to .data/prod/ for
+# local inspection (TablePlus, sqlite3, whatever).
+#
+#   npm run db:pull                 # host from PROD_SSH_HOST in .env
+#   npm run db:pull -- ubuntu@1.2.3.4
+#
+# The remote side opens the live DB read-only and uses VACUUM INTO, which is
+# safe against the running bot and cannot write to prod. What lands locally is a
+# standalone file with no WAL — never a mount of, or handle on, the real thing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_APP="${PROD_APP_DIR:-/opt/feed1}"
+REMOTE_DB="${PROD_DB_PATH:-$REMOTE_APP/.data/feed1.sqlite}"
+DEST="$REPO_ROOT/.data/prod/feed1-prod.sqlite"
+
+HOST="${1:-${PROD_SSH_HOST:-}}"
+if [[ -z "$HOST" && -f "$REPO_ROOT/.env" ]]; then
+  # `|| true`: a .env without the key must reach the message below, not trip pipefail
+  HOST="$(grep -E '^PROD_SSH_HOST=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)"
+  HOST="${HOST//[\"\' $'\r']/}"
+fi
+if [[ -z "$HOST" ]]; then
+  echo "no host: pass one (npm run db:pull -- ubuntu@1.2.3.4) or set PROD_SSH_HOST in .env" >&2
+  exit 1
+fi
+[[ "$HOST" == *@* ]] || HOST="ubuntu@$HOST"
+
+REMOTE_TMP="/tmp/feed1-snapshot-$$.sqlite"
+cleanup() { ssh "$HOST" "rm -f '$REMOTE_TMP'" </dev/null >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "snapshotting $HOST:$REMOTE_DB ..."
+ssh "$HOST" bash -s -- "$REMOTE_DB" "$REMOTE_TMP" "$REMOTE_APP" <<'REMOTE'
+set -euo pipefail
+DB="$1"; TMP="$2"; APP="$3"
+[[ -f "$DB" ]] || { echo "no database at $DB" >&2; exit 1; }
+rm -f "$TMP"
+node -e '
+const Database = require(process.argv[3] + "/node_modules/better-sqlite3");
+const db = new Database(process.argv[1], { readonly: true });
+db.prepare("VACUUM INTO ?").run(process.argv[2]);
+db.close();
+' "$DB" "$TMP" "$APP"
+REMOTE
+
+mkdir -p "$(dirname "$DEST")"
+scp -q "$HOST:$REMOTE_TMP" "$DEST.part"
+# a stale -wal beside a freshly replaced file is a corrupt read; TablePlus makes them
+rm -f "$DEST-wal" "$DEST-shm"
+mv "$DEST.part" "$DEST"
+
+echo "pulled $(du -h "$DEST" | cut -f1) -> ${DEST#"$REPO_ROOT/"}"


### PR DESCRIPTION
## What & why

Makes prod data queryable from a normal SQLite client (TablePlus, `sqlite3`, …) without ever
exposing the live database to one.

```sh
npm run db:pull                        # host from PROD_SSH_HOST in .env
npm run db:pull -- ubuntu@<vm-ip>      # or pass it
```

The snapshot lands at `.data/prod/feed1-prod.sqlite` (gitignored) — point a client at that path
once and re-run the command for fresh data. It's a point-in-time copy, which is the right trade
for the actual use case (poking at crowns/users while debugging).

The constraint driving the design: GUI clients open SQLite **read-write**, so pointing one at the
live `.data/feed1.sqlite` — over sshfs or any network mount — is the documented way to corrupt a
WAL database. Instead the remote side opens prod with `SQLITE_OPEN_READONLY` and runs
`VACUUM INTO`, which is safe against the running bot and physically cannot write to it. What comes
down is a standalone file with no WAL. Same mechanism `src/ops/backup.ts` already uses in prod.

There's no `sqlite3` CLI on the VM, so the snapshot runs through the `better-sqlite3` already
installed at `/opt/feed1`.

## Testing

Verified read-only `VACUUM INTO` works against a WAL database before building on it — the whole
design depends on that being true.

End-to-end against a stubbed remote with a live writer inserting every 50ms for the duration of
the pull:

- 526 rows captured, including all 26 written *during* the pull
- `journal_mode=delete` on the result — no WAL tagged along
- remote temp file cleaned up; nothing leaked into git

Failure paths: no host, `.env` fallback with a quoted value, missing remote DB. The `.env` case
caught a real bug — under `set -o pipefail`, a `.env` without `PROD_SSH_HOST` made `grep` exit 1
and killed the script before the "no host" message could print. Fixed and re-tested.

Also guards against a stale `-wal`/`-shm` left by a previous client session, which beside a
freshly replaced file is a corrupt read.

`lint`, `typecheck`, and all 187 tests pass.

**Not covered:** the SSH transport itself is stubbed in testing, so the first real run needs the
VM. `PROD_SSH_HOST` is in `.env.example`.

## Version

`2.3.1` — patch, no user-visible bot behaviour change.
