### PR TITLE
docs(ops): note that db:pull needs an ssh config entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ LASTFM_API_KEY=
 DB_PATH=.data/feed1.sqlite
 
 # Optional: prod host for `npm run db:pull` (user@host; bare host assumes ubuntu@)
+# Prefer an ssh config alias over a raw IP — the pull uses plain `ssh`, so the
+# key has to come from ~/.ssh/config or the agent, not from here.
 PROD_SSH_HOST=
 
 # Optional: comma-separated guildId:pageCap overrides for chart queue depth

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -110,6 +110,18 @@ npm run db:pull                        # host from PROD_SSH_HOST in .env
 npm run db:pull -- ubuntu@<vm-ip>      # or pass it
 ```
 
+The pull shells out to plain `ssh`/`scp`, so it can't tell you which key to use. Give the VM an
+`~/.ssh/config` entry and point `PROD_SSH_HOST` at that alias — a bare IP with the key sitting
+unreferenced in `~/.ssh/` fails with `Permission denied (publickey)`:
+
+```
+Host feed1-prod
+        HostName <vm-ip>
+        User ubuntu
+        IdentityFile ~/.ssh/id_feed1
+        IdentitiesOnly yes
+```
+
 Lands a snapshot at `.data/prod/feed1-prod.sqlite` (gitignored) for TablePlus, `sqlite3`, or
 anything else. It's a point-in-time copy — re-run it for fresh data.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What & why

`npm run db:pull` failed on its first real run against prod with `Permission denied (publickey)`,
despite `PROD_SSH_HOST` being set correctly. The cause wasn't the script: `db-pull.sh` shells out to
plain `ssh`/`scp` with no `-i` flag, so it inherits whatever identity the local SSH setup provides.
With no `Host` entry for the VM and an empty `ssh-agent`, ssh only offered the default filenames
(`id_rsa`, `id_ecdsa`, `id_ed25519`) and never tried the dedicated key sitting in `~/.ssh/`.

Setting the IP in `.env` tells the script *where* to connect but not *which key* to use — and
nothing in the docs said so. #24 shipped with the SSH transport exercised only through test shims,
so this gap went unnoticed until the first live pull.

No behaviour change; the fix is documentation. `deploy/README.md` now shows the `~/.ssh/config`
block and recommends pointing `PROD_SSH_HOST` at an alias rather than a raw IP, and `.env.example`
carries a short pointer to the same.

## Testing

Verified end-to-end against the live VM after adding the config entry:

```
snapshotting ubuntu@feed1-prod:/opt/feed1/.data/feed1.sqlite ...
pulled 4.7M -> .data/prod/feed1-prod.sqlite
```

The snapshot is sound — 10 tables, `journal_mode=delete` (no WAL alongside it), 55 rows in `users`.

## Version

Patch bump to `2.3.2`, per VERSIONING.md's rule that docs-only PRs still bump.