### PR TITLE
refactor(db): rename the crowns table to artist_crowns

### DIFF
--- a/drizzle/0001_rename_crowns_to_artist_crowns.sql
+++ b/drizzle/0001_rename_crowns_to_artist_crowns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `crowns` RENAME TO `artist_crowns`;--> statement-breakpoint
+DROP INDEX `crowns_guild_artist`;--> statement-breakpoint
+CREATE UNIQUE INDEX `artist_crowns_guild_artist` ON `artist_crowns` (`guild_id`,`artist_name`);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,598 @@
+{
+  "id": "4c16f838-2c45-4dd4-8f79-48ece952c7e0",
+  "prevId": "6007fbe1-d52b-45aa-ad79-5a8d0d071a39",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "album_crowns": {
+      "name": "album_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_plays": {
+          "name": "album_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "album_url": {
+          "name": "album_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "album_crowns_guild_artist_album": {
+          "name": "album_crowns_guild_artist_album",
+          "columns": [
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_audit": {
+      "name": "crown_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prev_owner_id": {
+          "name": "prev_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_owner_id": {
+          "name": "new_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_plays": {
+          "name": "prev_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_plays": {
+          "name": "new_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_jobs": {
+      "name": "crown_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "crown_jobs_dedupe": {
+          "name": "crown_jobs_dedupe",
+          "columns": [
+            "kind",
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artist_crowns": {
+      "name": "artist_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_plays": {
+          "name": "artist_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "artist_url": {
+          "name": "artist_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_img_url": {
+          "name": "artist_img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "artist_crowns_guild_artist": {
+          "name": "artist_crowns_guild_artist",
+          "columns": [
+            "guild_id",
+            "artist_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "disables": {
+      "name": "disables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command_name": {
+          "name": "command_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "disables_guild_command": {
+          "name": "disables_guild_command",
+          "columns": [
+            "guild_id",
+            "command_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notif_prefs": {
+      "name": "notif_prefs",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_win": {
+          "name": "on_win",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "on_loss": {
+          "name": "on_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_timings": {
+      "name": "scan_timings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ms": {
+          "name": "ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rym_username": {
+          "name": "rym_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rym_per_page": {
+          "name": "rym_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rym_max": {
+          "name": "rym_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wish_max": {
+          "name": "wish_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag_max": {
+          "name": "tag_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chart_url": {
+          "name": "chart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "columns": [
+            "discord_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784230224030,
       "tag": "0000_loose_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1785954122407,
+      "tag": "0001_rename_crowns_to_artist_crowns",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/crowns.ts
+++ b/src/commands/crowns.ts
@@ -62,9 +62,12 @@ async function listCrowns(ctx: CommandContext, kind: 'artist' | 'album'): Promis
     kind === 'artist'
       ? app.db
           .select()
-          .from(schema.crowns)
+          .from(schema.artistCrowns)
           .where(
-            and(eq(schema.crowns.guildId, message.guild!.id), eq(schema.crowns.userId, target.id)),
+            and(
+              eq(schema.artistCrowns.guildId, message.guild!.id),
+              eq(schema.artistCrowns.userId, target.id),
+            ),
           )
           .all()
           .map((r) => ({ label: r.artistName, url: r.artistUrl, plays: r.artistPlays }))
@@ -105,8 +108,8 @@ async function crownLeaderboard(ctx: CommandContext, kind: 'artist' | 'album'): 
     kind === 'artist'
       ? app.db
           .select()
-          .from(schema.crowns)
-          .where(eq(schema.crowns.guildId, message.guild!.id))
+          .from(schema.artistCrowns)
+          .where(eq(schema.artistCrowns.guildId, message.guild!.id))
           .all()
           .map((r) => r.userId)
       : app.db

--- a/src/crowns/service.ts
+++ b/src/crowns/service.ts
@@ -169,11 +169,11 @@ export class CrownService {
       kind === 'artist'
         ? this.db
             .select()
-            .from(schema.crowns)
+            .from(schema.artistCrowns)
             .where(
               and(
-                eq(schema.crowns.guildId, target.guildId),
-                eq(schema.crowns.artistName, target.artistName),
+                eq(schema.artistCrowns.guildId, target.guildId),
+                eq(schema.artistCrowns.artistName, target.artistName),
               ),
             )
             .get()
@@ -218,9 +218,13 @@ export class CrownService {
         updatedAt: new Date(this.now()),
       };
       if (existing) {
-        this.db.update(schema.crowns).set(values).where(eq(schema.crowns.id, existing.id)).run();
+        this.db
+          .update(schema.artistCrowns)
+          .set(values)
+          .where(eq(schema.artistCrowns.id, existing.id))
+          .run();
       } else {
-        this.db.insert(schema.crowns).values(values).run();
+        this.db.insert(schema.artistCrowns).values(values).run();
       }
     } else {
       const values = {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -20,8 +20,8 @@ export const users = sqliteTable('users', {
   createdAt: createdAt(),
 });
 
-export const crowns = sqliteTable(
-  'crowns',
+export const artistCrowns = sqliteTable(
+  'artist_crowns',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     guildId: text('guild_id').notNull(),
@@ -36,7 +36,7 @@ export const crowns = sqliteTable(
       .notNull()
       .default(sql`(unixepoch() * 1000)`),
   },
-  (t) => [uniqueIndex('crowns_guild_artist').on(t.guildId, t.artistName)],
+  (t) => [uniqueIndex('artist_crowns_guild_artist').on(t.guildId, t.artistName)],
 );
 
 export const albumCrowns = sqliteTable(

--- a/test/commands/crowns.test.ts
+++ b/test/commands/crowns.test.ts
@@ -11,7 +11,7 @@ function appWithCrowns() {
   const app = makeFakeApp(crownCommands);
   app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'lfm1' }).run();
   app.db
-    .insert(schema.crowns)
+    .insert(schema.artistCrowns)
     .values([
       { guildId: 'guild-1', userId: 'user-1', artistName: 'Autechre', artistPlays: 100 },
       { guildId: 'guild-1', userId: 'user-1', artistName: 'Aphex Twin', artistPlays: 1 },

--- a/test/commands/whoknows.test.ts
+++ b/test/commands/whoknows.test.ts
@@ -80,7 +80,7 @@ describe('&wk', () => {
     expect(embed.data.footer?.text).toContain('50 scrobbles | 2 listeners | 25 avg');
     expect(embed.data.footer?.text).toContain('this crown check took');
 
-    const crown = app.db.select().from(schema.crowns).all()[0]!;
+    const crown = app.db.select().from(schema.artistCrowns).all()[0]!;
     expect(crown.userId).toBe('user-2');
     expect(crown.artistPlays).toBe(40);
   });

--- a/test/crowns/service.test.ts
+++ b/test/crowns/service.test.ts
@@ -55,7 +55,7 @@ describe('CrownService artist crowns', () => {
       member('b'),
     ]);
 
-    const crown = db.select().from(schema.crowns).all()[0]!;
+    const crown = db.select().from(schema.artistCrowns).all()[0]!;
     expect(crown.userId).toBe('a');
     expect(crown.artistPlays).toBe(10);
     expect(crown.serverPlays).toBe(15);
@@ -68,7 +68,7 @@ describe('CrownService artist crowns', () => {
   it('does not create a crown when nobody has plays', async () => {
     const { db, service, changes } = makeService({ 'lfm-a': 0, 'lfm-b': 0 });
     await service.scan({ ...GUILD, artistName: 'Autechre' }, [member('a'), member('b')]);
-    expect(db.select().from(schema.crowns).all()).toHaveLength(0);
+    expect(db.select().from(schema.artistCrowns).all()).toHaveLength(0);
     expect(changes).toHaveLength(0);
   });
 
@@ -89,7 +89,7 @@ describe('CrownService artist crowns', () => {
     })();
     await s2.scan({ ...GUILD, artistName: 'Autechre' }, [member('a'), member('b')]);
 
-    const crown = db.select().from(schema.crowns).all()[0]!;
+    const crown = db.select().from(schema.artistCrowns).all()[0]!;
     expect(crown.userId).toBe('b');
     expect(crown.artistPlays).toBe(20);
     expect(c2).toHaveLength(2);
@@ -108,7 +108,7 @@ describe('CrownService artist crowns', () => {
     );
     await s2.scan({ ...GUILD, artistName: 'Autechre' }, [member('a'), member('b')]);
 
-    expect(db.select().from(schema.crowns).all()[0]!.userId).toBe('a');
+    expect(db.select().from(schema.artistCrowns).all()[0]!.userId).toBe('a');
   });
 
   it('reassigns when the incumbent left the guild', async () => {
@@ -124,7 +124,7 @@ describe('CrownService artist crowns', () => {
     // member a no longer in the member list
     await s2.scan({ ...GUILD, artistName: 'Autechre' }, [member('b')]);
 
-    const crown = db.select().from(schema.crowns).all()[0]!;
+    const crown = db.select().from(schema.artistCrowns).all()[0]!;
     expect(crown.userId).toBe('b');
     expect(crown.artistPlays).toBe(5);
   });
@@ -187,7 +187,7 @@ describe('CrownService album crowns', () => {
     const { db, service } = makeService({ 'lfm-a': 4 });
     await service.scan({ ...GUILD, artistName: 'Autechre' }, [member('a')]);
     await service.scan({ ...GUILD, artistName: 'Autechre', albumName: 'Confield' }, [member('a')]);
-    expect(db.select().from(schema.crowns).all()).toHaveLength(1);
+    expect(db.select().from(schema.artistCrowns).all()).toHaveLength(1);
     expect(db.select().from(schema.albumCrowns).all()).toHaveLength(1);
   });
 });
@@ -225,7 +225,7 @@ describe('CrownService concurrency', () => {
     await slowRun;
 
     // the same owner both times; the crown row exists exactly once
-    const rows = db.select().from(schema.crowns).all();
+    const rows = db.select().from(schema.artistCrowns).all();
     expect(rows).toHaveLength(1);
     expect(rows[0]!.userId).toBe('a');
   });

--- a/test/db/migration.test.ts
+++ b/test/db/migration.test.ts
@@ -1,0 +1,97 @@
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { createDb, runMigrations, schema } from '../../src/db/index.js';
+
+/**
+ * A migrations folder holding only the entries up to and including `upToIdx`, so a
+ * test can stand up an older schema and then migrate forward across it.
+ */
+function migrationsFolderUpTo(upToIdx: number): string {
+  const journal = JSON.parse(readFileSync('drizzle/meta/_journal.json', 'utf8')) as {
+    entries: { idx: number; tag: string }[];
+  };
+  const entries = journal.entries.filter((e) => e.idx <= upToIdx);
+  const dir = mkdtempSync(join(tmpdir(), 'feed1-migrations-'));
+  mkdirSync(join(dir, 'meta'));
+  writeFileSync(join(dir, 'meta', '_journal.json'), JSON.stringify({ ...journal, entries }));
+  for (const entry of entries) {
+    copyFileSync(`drizzle/${entry.tag}.sql`, join(dir, `${entry.tag}.sql`));
+  }
+  return dir;
+}
+
+describe('0001 rename crowns -> artist_crowns', () => {
+  // the migrator applies by created_at and never compares the stored hash, so a reused
+  // database would silently skip 0001 and pass this suite vacuously
+  function dbAtMigration0000() {
+    const db = createDb(':memory:');
+    runMigrations(db, migrationsFolderUpTo(0));
+    return db;
+  }
+
+  it('carries existing crowns across the rename', () => {
+    const db = dbAtMigration0000();
+    db.run(
+      sql`insert into crowns (guild_id, user_id, artist_name, artist_plays, server_plays, server_listeners)
+          values ('g1', 'u1', 'Autechre', 100, 250, 3), ('g1', 'u2', 'Boards of Canada', 40, 90, 2)`,
+    );
+
+    runMigrations(db);
+
+    const rows = db.select().from(schema.artistCrowns).all();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => [r.artistName, r.userId, r.artistPlays, r.serverPlays])).toEqual([
+      ['Autechre', 'u1', 100, 250],
+      ['Boards of Canada', 'u2', 40, 90],
+    ]);
+  });
+
+  it('leaves no crowns table behind', () => {
+    const db = dbAtMigration0000();
+    runMigrations(db);
+
+    const tables = db
+      .all<{ name: string }>(sql`select name from sqlite_master where type = 'table'`)
+      .map((r) => r.name);
+    expect(tables).toContain('artist_crowns');
+    expect(tables).not.toContain('crowns');
+    expect(tables).toContain('album_crowns');
+  });
+
+  it('keeps the guild+artist uniqueness constraint after the index is rebuilt', () => {
+    const db = dbAtMigration0000();
+    db.run(
+      sql`insert into crowns (guild_id, user_id, artist_name, artist_plays) values ('g1', 'u1', 'Autechre', 100)`,
+    );
+
+    runMigrations(db);
+
+    const indexes = db
+      .all<{ name: string }>(
+        sql`select name from sqlite_master where type = 'index' and tbl_name = 'artist_crowns'`,
+      )
+      .map((r) => r.name);
+    expect(indexes).toContain('artist_crowns_guild_artist');
+    expect(() =>
+      db
+        .insert(schema.artistCrowns)
+        .values({ guildId: 'g1', userId: 'u2', artistName: 'Autechre', artistPlays: 5 })
+        .run(),
+    ).toThrow(/UNIQUE/);
+  });
+
+  it('does not disturb album_crowns rows', () => {
+    const db = dbAtMigration0000();
+    db.run(
+      sql`insert into album_crowns (guild_id, user_id, artist_name, album_name, album_plays)
+          values ('g1', 'u1', 'Autechre', 'Confield', 20)`,
+    );
+
+    runMigrations(db);
+
+    expect(db.select().from(schema.albumCrowns).all()).toHaveLength(1);
+  });
+});

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -16,8 +16,8 @@ describe('schema', () => {
   it('enforces one crown per guild+artist', () => {
     const db = freshDb();
     const row = { guildId: 'g1', userId: 'u1', artistName: 'Autechre', artistPlays: 100 };
-    db.insert(schema.crowns).values(row).run();
-    expect(() => db.insert(schema.crowns).values({ ...row, userId: 'u2' }).run()).toThrow(
+    db.insert(schema.artistCrowns).values(row).run();
+    expect(() => db.insert(schema.artistCrowns).values({ ...row, userId: 'u2' }).run()).toThrow(
       /UNIQUE/,
     );
   });
@@ -45,10 +45,10 @@ describe('schema', () => {
 
   it('stores numeric playcounts as integers', () => {
     const db = freshDb();
-    db.insert(schema.crowns)
+    db.insert(schema.artistCrowns)
       .values({ guildId: 'g1', userId: 'u1', artistName: 'a', artistPlays: 42 })
       .run();
-    const crown = db.select().from(schema.crowns).all()[0];
+    const crown = db.select().from(schema.artistCrowns).all()[0];
     expect(crown?.artistPlays).toBe(42);
     expect(typeof crown?.artistPlays).toBe('number');
   });


### PR DESCRIPTION
## What & why

The artist-crown table was called `crowns` while its sibling is `album_crowns`, so the schema read as "crowns vs album crowns" rather than "artist vs album". This renames the table to `artist_crowns`, the Drizzle export to `artistCrowns`, and the unique index to `artist_crowns_guild_artist`.

Nothing user-visible moves. The `-crowns` command, its aliases, all help text and every output string are untouched, as is `album_crowns`. The only raw occurrence of the table name in the repo was `src/db/schema.ts`; `src/ops/backup.ts` enumerates tables from `sqlite_master`, so its report picks up the new name for free.

## The migration

`drizzle/0001_rename_crowns_to_artist_crowns.sql` is hand-written as `ALTER TABLE … RENAME TO` plus an index rebuild — deliberately *not* generated. drizzle-kit cannot tell a rename from a drop-and-create, and against this schema change `drizzle-kit generate` hits an interactive rename prompt and errors out in any non-TTY. The file was created with `generate --custom`, which sidesteps the prompt but copies the previous snapshot verbatim, so `drizzle/meta/0001_snapshot.json` was corrected by hand. That correction is verified rather than trusted: `npx drizzle-kit generate` now reports `No schema changes, nothing to migrate`, which it can only do when snapshot and schema agree.

## Testing

- New `test/db/migration.test.ts` applies `0000` alone, inserts crown rows, migrates forward, and asserts the rows survive under `artist_crowns` with the uniqueness constraint intact and no `crowns` table left behind. Mutation-checked: replacing the migration with the drop-and-create form fails 2 of its 4 tests, so the guard is real. Each case builds a fresh DB — the migrator gates on `created_at` and never compares the stored hash, so a reused DB would skip `0001` and pass vacuously.
- Rehearsed against a copy of the live database (`db:pull` snapshot) through the real `runMigrations()` path: **4,953 rows in, 4,953 rows out**, row ids and every column preserved, correct index, `album_crowns` and `crown_audit` untouched, and idempotent on a second run.
- `typecheck`, `lint`, `build` clean; 191 tests pass (187 + 4 new).

## Deploy note

This is the repo's second migration, so it creates a **rollback boundary** — reverting to ≤ v2.3.2 will be refused by the migration guard unless re-run with `force_across_migrations=true` and the pre-deploy snapshot restored. No manual DB work is needed for the forward deploy: the service is stopped, a snapshot is taken, and the migration applies at startup of the new code.