### PR TITLE
fix(rym): show one pick per page in -rand and -wrand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/rym.ts
+++ b/src/commands/rym.ts
@@ -306,7 +306,7 @@ const ch: Command = {
 };
 
 const RAND_MAX_PICKS = 100;
-const RAND_PER_PAGE = 10;
+const RAND_PER_PAGE = 1;
 
 function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;

--- a/test/commands/rym.test.ts
+++ b/test/commands/rym.test.ts
@@ -25,19 +25,66 @@ function userRow(app: ReturnType<typeof makeFakeApp>) {
   return app.db.select().from(schema.users).all()[0]!;
 }
 
-/** Replaces channel.send with a stub whose sent message survives the multi-page collector path. */
-function patchChannelSend(fake: ReturnType<typeof makeFakeMessage>): EmbedBuilder[] {
-  const captured: EmbedBuilder[] = [];
+type SendPayload = { embeds?: EmbedBuilder[]; components?: { components: unknown[] }[] };
+type CollectHandler = (interaction: unknown) => Promise<void> | void;
+
+/**
+ * Drives the button pager the way a user does. `sendPaginatedEmbed` only ever passes page 1 to
+ * channel.send — pages 2..N exist solely inside the collector's update calls, so a stub that
+ * discards the collect handler can't see them.
+ */
+function patchPager(fake: ReturnType<typeof makeFakeMessage>, invokerId = 'user-1') {
+  let initial: SendPayload | undefined;
+  let onCollect: CollectHandler | undefined;
   const channel = fake.message.channel as unknown as { send: (p: unknown) => Promise<unknown> };
   channel.send = (payload: unknown) => {
-    const p = payload as { embeds?: EmbedBuilder[] };
-    if (p.embeds) captured.push(...p.embeds);
+    initial ??= payload as SendPayload;
     return Promise.resolve({
-      createMessageComponentCollector: () => ({ on: () => undefined }),
+      createMessageComponentCollector: () => ({
+        on: (event: string, handler: CollectHandler) => {
+          if (event === 'collect') onCollect = handler;
+        },
+      }),
       edit: () => Promise.resolve(undefined),
     });
   };
-  return captured;
+
+  const firstPage = () => {
+    if (!initial?.embeds?.[0]) throw new Error('pager never sent an embed');
+    return initial.embeds[0];
+  };
+
+  /** Total page count, parsed from the `page no. N/total` footer — the only place it is exposed. */
+  const totalPages = () => {
+    const footer = firstPage().data.footer?.text ?? '';
+    const m = /^page no\. \d+\/(\d+)/.exec(footer);
+    if (!m) throw new Error(`footer has no page total: ${footer}`);
+    return parseInt(m[1]!, 10);
+  };
+
+  return {
+    get initial() {
+      return initial;
+    },
+    totalPages,
+    /** Every page in order, page 1 first, by clicking ➡ until the last page. */
+    async pages(): Promise<EmbedBuilder[]> {
+      const collected = [firstPage()];
+      const total = totalPages();
+      if (total > 1 && !onCollect) throw new Error('multi-page send registered no collect handler');
+      for (let i = 1; i < total; i++) {
+        await onCollect!({
+          customId: 'next',
+          user: { id: invokerId },
+          update: (p: SendPayload) => {
+            if (p.embeds?.[0]) collected.push(p.embeds[0]);
+            return Promise.resolve(undefined);
+          },
+        });
+      }
+      return collected;
+    },
+  };
 }
 
 describe('not logged into rym', () => {
@@ -286,20 +333,22 @@ describe('&rand', () => {
     );
   });
 
-  it('sends a single page of unique links within [1..max]', async () => {
+  it('sends one rating per page, unique and within [1..max]', async () => {
     const app = appWithUser({ rymMax: 10 });
     const fake = makeFakeMessage({ content: '&rand' });
+    const pager = patchPager(fake);
     await byName('rand').run({ app, message: fake.message, args: [] });
 
-    const embed = fake.embeds[0] as EmbedBuilder;
-    expect(embed.data.title).toBe('🎲  Rating Randomizer (MAX: 10)  🎲');
-    expect(embed.data.footer?.text).toBe('page no. 1/1 | set max with &max #_of_rym_ratings');
+    const pages = await pager.pages();
+    expect(pages).toHaveLength(10);
+    expect(pages[0]!.data.title).toBe('🎲  Rating Randomizer (MAX: 10)  🎲');
+    expect(pages[0]!.data.footer?.text).toBe('page no. 1/10 | set max with &max #_of_rym_ratings');
 
-    const lines = (embed.data.description ?? '').split('\n');
-    expect(lines).toHaveLength(10);
-    const picks = lines.map((line) => {
+    const picks = pages.map((page) => {
+      const lines = (page.data.description ?? '').split('\n');
+      expect(lines).toHaveLength(1);
       const m = /^\[Rating No\. (\d+)\]\(https:\/\/rateyourmusic\.com\/collection\/testrym\/r0\.5-5\.0,ss\.d,n1\/(\d+)\)$/.exec(
-        line,
+        lines[0]!,
       );
       expect(m).not.toBeNull();
       expect(m![1]).toBe(m![2]);
@@ -312,15 +361,28 @@ describe('&rand', () => {
     }
   });
 
-  it('caps at 100 picks (10 pages) for a large max', async () => {
+  it('caps at 100 picks (100 pages) for a large max', async () => {
     const app = appWithUser({ rymMax: 500 });
     const fake = makeFakeMessage({ content: '&rand' });
-    const captured = patchChannelSend(fake);
+    const pager = patchPager(fake);
     await byName('rand').run({ app, message: fake.message, args: [] });
 
-    const first = captured[0]!;
-    expect(first.data.footer?.text).toBe('page no. 1/10 | set max with &max #_of_rym_ratings');
-    expect((first.data.description ?? '').split('\n')).toHaveLength(10);
+    const pages = await pager.pages();
+    expect(pages).toHaveLength(100);
+    expect(pages[0]!.data.footer?.text).toBe('page no. 1/100 | set max with &max #_of_rym_ratings');
+
+    const picks = pages.map((page) => {
+      const lines = (page.data.description ?? '').split('\n');
+      expect(lines).toHaveLength(1);
+      const m = /\/r0\.5-5\.0,ss\.d,n1\/(\d+)\)$/.exec(lines[0]!);
+      expect(m).not.toBeNull();
+      return parseInt(m![1]!, 10);
+    });
+    expect(new Set(picks).size).toBe(100);
+    for (const p of picks) {
+      expect(p).toBeGreaterThanOrEqual(1);
+      expect(p).toBeLessThanOrEqual(500);
+    }
   });
 });
 
@@ -334,24 +396,61 @@ describe('&wrand', () => {
     );
   });
 
-  it('sends wishlist links within [1..wishMax]', async () => {
+  it('sends one wishlist item per page, unique and within [1..wishMax]', async () => {
     const app = appWithUser({ wishMax: 5 });
     const fake = makeFakeMessage({ content: '&wrand' });
+    const pager = patchPager(fake);
     await byName('wrand').run({ app, message: fake.message, args: [] });
 
-    const embed = fake.embeds[0] as EmbedBuilder;
-    expect(embed.data.title).toBe('🎲  Wishlist Randomizer (WMAX: 5)  🎲');
-    const lines = (embed.data.description ?? '').split('\n');
-    expect(lines).toHaveLength(5);
-    for (const line of lines) {
+    const pages = await pager.pages();
+    expect(pages).toHaveLength(5);
+    expect(pages[0]!.data.title).toBe('🎲  Wishlist Randomizer (WMAX: 5)  🎲');
+    expect(pages[0]!.data.footer?.text).toBe('page no. 1/5 | set wmax with &wmax #');
+
+    const picks = pages.map((page) => {
+      const lines = (page.data.description ?? '').split('\n');
+      expect(lines).toHaveLength(1);
       const m = /^\[Wishlist Item No\. (\d+)\]\(https:\/\/rateyourmusic\.com\/collection\/testrym\/wishlist,n1\/(\d+)\)$/.exec(
-        line,
+        lines[0]!,
       );
       expect(m).not.toBeNull();
-      const p = parseInt(m![1]!, 10);
+      expect(m![1]).toBe(m![2]);
+      return parseInt(m![1]!, 10);
+    });
+    expect(new Set(picks).size).toBe(5);
+    for (const p of picks) {
       expect(p).toBeGreaterThanOrEqual(1);
       expect(p).toBeLessThanOrEqual(5);
     }
+  });
+
+  it('offers reroll arrows with prev disabled on the first page', async () => {
+    const app = appWithUser({ wishMax: 5 });
+    const fake = makeFakeMessage({ content: '&wrand' });
+    const pager = patchPager(fake);
+    await byName('wrand').run({ app, message: fake.message, args: [] });
+
+    const rows = pager.initial?.components ?? [];
+    expect(rows).toHaveLength(1);
+    const buttons = rows[0]!.components as { data: { disabled?: boolean } }[];
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]!.data.disabled).toBe(true);
+    expect(buttons[1]!.data.disabled).toBeFalsy();
+  });
+
+  it('sends a lone buttonless page when wishMax is 1', async () => {
+    const app = appWithUser({ wishMax: 1 });
+    const fake = makeFakeMessage({ content: '&wrand' });
+    const pager = patchPager(fake);
+    await byName('wrand').run({ app, message: fake.message, args: [] });
+
+    expect(pager.initial?.embeds).toHaveLength(1);
+    expect(pager.initial?.components).toBeUndefined();
+    const embed = pager.initial!.embeds![0]!;
+    expect(embed.data.footer?.text).toBe('page no. 1/1 | set wmax with &wmax #');
+    expect(embed.data.description).toBe(
+      '[Wishlist Item No. 1](https://rateyourmusic.com/collection/testrym/wishlist,n1/1)',
+    );
   });
 });
 


### PR DESCRIPTION
## What & why

`-wrand` rendered ten wishlist links at once under a title that says "Wishlist Randomizer", which reads as broken — the point of the command is *one* random pick you reroll with the arrows. Legacy `wrand.js` showed exactly one item per page; the 2.0 rewrite folded `rand` and `wrand` into a shared `randomizerCommand()` factory and set `RAND_PER_PAGE = 10` for both, so `-rand` has the identical regression.

This sets that constant to `1`, restoring the legacy shape for both commands. The rewrite's 100-pick cap stays: legacy paged through the entire `max`, which meant up to 5296 single-item pages for a large wishlist. The footer keeps its `page no. N/total` form rather than legacy's total-less `page no. N`, since the total is what tells you where paging stops — and the cap it reports is itself a deliberate deviation.

`trand` and `srand` are untouched; neither uses the pager.

## Testing

The production diff is one character, but the tests needed real work. `sendPaginatedEmbed` only ever passes page 1 to `channel.send` — pages 2..N exist solely inside the collector's `interaction.update()` calls, and the old `patchChannelSend` stub discarded the collect handler. At ten picks per page that stub still saw most of the result set; at one per page it saw 1%.

So it's replaced by a `patchPager` harness that retains the collect handler and walks the pages by simulating ➡ clicks. That preserves the existing coverage (all picks distinct and in range) and closes a gap that predates this change: nothing anywhere asserted button behavior.

- `&rand` — 10 pages at `rymMax: 10`, one line each, 10 distinct picks in `[1..10]`
- `&rand` — caps at 100 pages for `rymMax: 500`, 100 distinct picks
- `&wrand` — 5 pages at `wishMax: 5`, one line each, footer `page no. 1/5`
- `&wrand` — action row present with `prev` disabled and `next` enabled on page 1 (new)
- `&wrand` — `wishMax: 1` sends a lone page with **no** components (new)

Mutation-tested: reverting `RAND_PER_PAGE` to `10` fails 4 of the 5. The `wishMax: 1` case passes either way by design — one pick is one page regardless of page size; that test pins the buttonless boundary legacy guarded with `if (parseInt(max) > 1)`.

Full suite green: typecheck, lint, 193 tests, build.

## Follow-up worth knowing about

`PAGE_TIMEOUT_MS` is 120s (`src/core/paginate.ts:12`), after which the arrows are stripped. At ten per page you saw most results immediately; at one per page, browsing 100 picks is 99 clicks against a two-minute budget, where legacy's reaction pager never expired. Raising it would also change `-crowns` and `-wk`, so it's deliberately out of scope here — but it's the likely next complaint.