### PR TITLE
feat(db): record last_used timestamp when a user runs a command

### DIFF
--- a/drizzle/0002_ambiguous_roland_deschain.sql
+++ b/drizzle/0002_ambiguous_roland_deschain.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `last_used` integer;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,605 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "58a0d6fa-55ca-4dad-8e71-81cdd6954a96",
+  "prevId": "4c16f838-2c45-4dd4-8f79-48ece952c7e0",
+  "tables": {
+    "album_crowns": {
+      "name": "album_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_plays": {
+          "name": "album_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "album_url": {
+          "name": "album_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "album_crowns_guild_artist_album": {
+          "name": "album_crowns_guild_artist_album",
+          "columns": [
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artist_crowns": {
+      "name": "artist_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_plays": {
+          "name": "artist_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "artist_url": {
+          "name": "artist_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_img_url": {
+          "name": "artist_img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "artist_crowns_guild_artist": {
+          "name": "artist_crowns_guild_artist",
+          "columns": [
+            "guild_id",
+            "artist_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_audit": {
+      "name": "crown_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prev_owner_id": {
+          "name": "prev_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_owner_id": {
+          "name": "new_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_plays": {
+          "name": "prev_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_plays": {
+          "name": "new_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_jobs": {
+      "name": "crown_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "crown_jobs_dedupe": {
+          "name": "crown_jobs_dedupe",
+          "columns": [
+            "kind",
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "disables": {
+      "name": "disables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command_name": {
+          "name": "command_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "disables_guild_command": {
+          "name": "disables_guild_command",
+          "columns": [
+            "guild_id",
+            "command_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notif_prefs": {
+      "name": "notif_prefs",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_win": {
+          "name": "on_win",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "on_loss": {
+          "name": "on_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_timings": {
+      "name": "scan_timings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ms": {
+          "name": "ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rym_username": {
+          "name": "rym_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rym_per_page": {
+          "name": "rym_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rym_max": {
+          "name": "rym_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wish_max": {
+          "name": "wish_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag_max": {
+          "name": "tag_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chart_url": {
+          "name": "chart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "columns": [
+            "discord_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785954122407,
       "tag": "0001_rename_crowns_to_artist_crowns",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1786726480344,
+      "tag": "0002_ambiguous_roland_deschain",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.3.4",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -1,6 +1,8 @@
 import type { Message } from 'discord.js';
+import { eq } from 'drizzle-orm';
 import type { AppContext } from './command.js';
 import { disabledScope } from './disables.js';
+import { users } from '../db/schema.js';
 
 const COOLDOWN_MS = 2000;
 
@@ -45,6 +47,11 @@ export class Router {
     const last = this.lastUse.get(message.author.id) ?? 0;
     if (now - last < COOLDOWN_MS) return;
     this.lastUse.set(message.author.id, now);
+    this.app.db
+      .update(users)
+      .set({ lastUsed: new Date() })
+      .where(eq(users.discordUserId, message.author.id))
+      .run();
 
     try {
       await command.run({ app: this.app, message, args: parts });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -18,6 +18,7 @@ export const users = sqliteTable('users', {
   tag: text('tag'),
   chartUrl: text('chart_url'),
   createdAt: createdAt(),
+  lastUsed: integer('last_used', { mode: 'timestamp_ms' }),
 });
 
 export const artistCrowns = sqliteTable(

--- a/test/core/router.test.ts
+++ b/test/core/router.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Command } from '../../src/core/command.js';
 import { Router } from '../../src/core/router.js';
 import { disableCommand } from '../../src/core/disables.js';
+import { schema } from '../../src/db/index.js';
 import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
 
 function testCommand(overrides: Partial<Command> = {}): Command & { calls: number } {
@@ -87,6 +88,59 @@ describe('Router', () => {
 
     await router.handle(makeFakeMessage({ content: '&fm', authorId: 'other' }).message);
     expect(cmd.calls).toBe(2);
+  });
+
+  it('records last use when a registered user runs a valid command', async () => {
+    const cmd = testCommand();
+    const app = makeFakeApp([cmd]);
+    app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'lfm1' }).run();
+    const router = new Router(app);
+    const usedAt = new Date('2026-08-14T12:00:00.000Z');
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(usedAt);
+      await router.handle(makeFakeMessage({ content: '&fm' }).message);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const row = app.db.select().from(schema.users).get();
+    expect(row?.lastUsed).toEqual(usedAt);
+  });
+
+  it('does not insert a user row when an unregistered user runs a command', async () => {
+    const cmd = testCommand();
+    const app = makeFakeApp([cmd]);
+    const router = new Router(app);
+
+    await router.handle(makeFakeMessage({ content: '&fm' }).message);
+
+    expect(cmd.calls).toBe(1);
+    expect(app.db.select().from(schema.users).all()).toEqual([]);
+  });
+
+  it('does not update last use for cooldown-suppressed messages', async () => {
+    const cmd = testCommand();
+    const app = makeFakeApp([cmd]);
+    app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'lfm1' }).run();
+    const router = new Router(app);
+    const firstUse = new Date('2026-08-14T12:00:00.000Z');
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(firstUse);
+      await router.handle(makeFakeMessage({ content: '&fm' }).message);
+
+      vi.setSystemTime(new Date(firstUse.getTime() + 1000));
+      await router.handle(makeFakeMessage({ content: '&fm' }).message);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const row = app.db.select().from(schema.users).get();
+    expect(cmd.calls).toBe(1);
+    expect(row?.lastUsed).toEqual(firstUse);
   });
 
   it('blocks owner-only commands for non-owners', async () => {


### PR DESCRIPTION
## What & why

The `users` table tracked when someone registered but never whether they were still around. This adds a nullable `last_used` timestamp to `users`, stamped every time that user actually runs a command — giving us a basis for activity questions (who's gone quiet, who's active in a guild) that previously required trawling logs.

The write lives in `Router.handle`, placed deliberately: it runs *after* the disable checks and *after* the cooldown gate, so a disabled command or a rate-limited message burst doesn't count as a use. It's a plain `UPDATE ... WHERE discord_user_id = ?`, so an unregistered caller is a harmless zero-row update rather than an implicit registration.

Existing rows stay `NULL` until their owner's next command; nothing backfills.

## Testing

`npm run typecheck`, `npm run lint`, `npm test` — 196 tests pass.

Three new router tests cover the cases that define the column's meaning:
- a registered user running a valid command stamps `last_used`
- an unregistered user runs fine and creates no row
- a cooldown-suppressed second message leaves `last_used` at the first timestamp

## Notes

Nothing reads the column yet — this is the schema and the write path only.

Version bumped 2.3.4 → 2.4.0 (additive feature).