### PR TITLE
feat(banner): remove the per-guild image cap

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -143,8 +143,8 @@ file with no WAL.
 - Logs: `journalctl -u feed1 -f`
 - DB + rotated backups live in `/opt/feed1/.data/` (12-hourly, keeps 20), plus a
   `predeploy_*.sqlite` snapshot per deploy. All snapshots use `VACUUM INTO`.
-- `-banner` images live in `/opt/feed1/.data/banners/<guildId>/`, capped at 100 per guild
-  (~200 MB worst case against 45 GB of disk). The deploy's `rsync --delete` excludes `.data`,
+- `-banner` images live in `/opt/feed1/.data/banners/<guildId>/`, uncapped — each is at most 10 MB,
+  so growth is worth an occasional `du -sh`. The deploy's `rsync --delete` excludes `.data`,
   so they survive merges — but **backups only cover the SQLite file, not these**. Losing the
   volume means re-adding banners by hand; the rows in `banner_images` will point at files that
   are gone, and rotation skips them rather than failing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/banner/store.ts
+++ b/src/banner/store.ts
@@ -6,17 +6,7 @@ import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
 import type { LoadedImage } from './image.js';
 
-/** Per-guild ceiling, so one server can't fill the VM's disk. */
-export const MAX_IMAGES_PER_GUILD = 100;
-
 export type BannerImage = typeof schema.bannerImages.$inferSelect;
-
-export class GuildImageLimitReached extends Error {
-  constructor() {
-    super(`this server already has ${MAX_IMAGES_PER_GUILD} banner images`);
-    this.name = 'GuildImageLimitReached';
-  }
-}
 
 const EXTENSIONS: Record<string, string> = {
   'image/png': 'png',
@@ -82,8 +72,6 @@ export class BannerImageStore {
       .where(and(eq(schema.bannerImages.guildId, guildId), eq(schema.bannerImages.sha256, sha256)))
       .get();
     if (existing) return { image: existing, added: false };
-
-    if (this.count(guildId) >= MAX_IMAGES_PER_GUILD) throw new GuildImageLimitReached();
 
     const file = this.pathFor(guildId, sha256, image.contentType);
     mkdirSync(dirname(file), { recursive: true });

--- a/src/commands/banner.ts
+++ b/src/commands/banner.ts
@@ -12,7 +12,6 @@ import {
 import type { BannerConfig, RotateResult } from '../banner/service.js';
 import { ImageTooLarge, UnsupportedImageType, fetchImage, isOffRatio } from '../banner/image.js';
 import type { LoadedImage } from '../banner/image.js';
-import { GuildImageLimitReached, MAX_IMAGES_PER_GUILD } from '../banner/store.js';
 import type { BannerImage } from '../banner/store.js';
 
 const IMAGES_PER_PAGE = 10;
@@ -114,7 +113,7 @@ async function usage(ctx: CommandContext): Promise<unknown> {
         name: 'add',
         value:
           `\`${p}banner add\` — with an image attached, with a link, or as a **reply** to a ` +
-          `message that has one. Up to ${MAX_IMAGES_PER_GUILD} per server.`,
+          `message that has one.`,
       },
       { name: 'list', value: `\`${p}banner list\` — every stored image, with its number.` },
       {
@@ -170,21 +169,10 @@ async function add(ctx: CommandContext, args: string[]): Promise<unknown> {
     );
   }
 
-  let stored;
-  try {
-    stored = app.bannerService.store.add(guild.id, image, {
-      addedBy: message.author.id,
-      sourceUrl: url,
-    });
-  } catch (error) {
-    if (error instanceof GuildImageLimitReached) {
-      return message.reply(
-        `this server is at the ${MAX_IMAGES_PER_GUILD} image limit — ` +
-          `\`${p}banner remove <number>\` to make room.`,
-      );
-    }
-    throw error;
-  }
+  const stored = app.bannerService.store.add(guild.id, image, {
+    addedBy: message.author.id,
+    sourceUrl: url,
+  });
 
   if (!stored.added) {
     return message.reply(`that image is already in the pool (number ${stored.image.id}).`);
@@ -256,7 +244,7 @@ async function list(ctx: CommandContext): Promise<unknown> {
   const pages = paginateLines(images.map(imageLine), IMAGES_PER_PAGE);
   const embeds = pages.map((body, index) =>
     new EmbedBuilder()
-      .setTitle(`banner images (${images.length}/${MAX_IMAGES_PER_GUILD})`)
+      .setTitle(`banner images (${images.length})`)
       .setDescription(body)
       .setFooter({
         text:

--- a/test/banner/store.test.ts
+++ b/test/banner/store.test.ts
@@ -2,11 +2,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import {
-  BannerImageStore,
-  GuildImageLimitReached,
-  MAX_IMAGES_PER_GUILD,
-} from '../../src/banner/store.js';
+import { BannerImageStore } from '../../src/banner/store.js';
 import { inspectImage } from '../../src/banner/image.js';
 import { createDb, runMigrations, schema } from '../../src/db/index.js';
 
@@ -121,13 +117,12 @@ describe('BannerImageStore', () => {
     expect(store.count('g2')).toBe(1);
   });
 
-  it('refuses to go past the per-guild limit', () => {
+  it('keeps accepting images past the old 100-image ceiling', () => {
     const { store } = makeStore();
-    for (let i = 0; i < MAX_IMAGES_PER_GUILD; i++) {
+    for (let i = 0; i < 120; i++) {
       store.add('g1', inspectImage(png(i)), meta);
     }
-    expect(() => store.add('g1', inspectImage(png(999)), meta)).toThrow(GuildImageLimitReached);
-    expect(store.count('g1')).toBe(MAX_IMAGES_PER_GUILD);
+    expect(store.count('g1')).toBe(120);
   });
 
   // the file can vanish under us (disk wipe, manual cleanup); the row must not crash a rotation

--- a/test/commands/banner.test.ts
+++ b/test/commands/banner.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import type { EmbedBuilder } from 'discord.js';
 import { bannerCommands, parseInterval } from '../../src/commands/banner.js';
 import { inspectImage } from '../../src/banner/image.js';
-import { MAX_IMAGES_PER_GUILD } from '../../src/banner/store.js';
 import { schema } from '../../src/db/index.js';
 import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
 import type { FakeApp, FakeMessage } from '../helpers/fake.js';
@@ -213,12 +212,12 @@ describe('&banner add', () => {
     expect(a.bannerService.store.count('guild-1')).toBe(1);
   });
 
-  it('refuses past the per-guild limit', async () => {
+  it('accepts an image on a server that is already past 100', async () => {
     stubFetch({ 'https://cdn.discord/last.png': png(200) });
     const a = app();
     seedImages(
       a,
-      Array.from({ length: MAX_IMAGES_PER_GUILD }, (_, i) => png(i)),
+      Array.from({ length: 100 }, (_, i) => png(i)),
     );
     const fake = makeFakeMessage({
       content: '&banner add',
@@ -227,7 +226,7 @@ describe('&banner add', () => {
 
     await run(a, fake, ['add']);
 
-    expect(fake.replies[0]).toMatch(new RegExp(`at the ${MAX_IMAGES_PER_GUILD} image limit`));
+    expect(fake.replies[0]).toMatch(/added as number 101/);
   });
 });
 
@@ -278,7 +277,7 @@ describe('&banner remove / list', () => {
     await run(a, fake, ['list']);
 
     const embed = (fake.embeds[0] as EmbedBuilder).toJSON();
-    expect(embed.title).toBe(`banner images (2/${MAX_IMAGES_PER_GUILD})`);
+    expect(embed.title).toBe('banner images (2)');
     expect(embed.description).toMatch(/`1\.`.*1920×1080/);
     expect(embed.footer?.text).toMatch(/total/);
   });


### PR DESCRIPTION
## What & why

`-banner add` refused a 101st image per server. The pool being migrated across from Banner Boi for
Feel's server is 217 images, so the cap blocks the migration it was written for.

Removed rather than raised. A ceiling that has to be edited and deployed every time someone's
collection grows isn't buying much, and the real constraint is disk, which a per-guild count doesn't
measure — 100 thumbnails and 100 near-10 MB PNGs are two very different numbers.

**The trade-off, stated plainly:** nothing now bounds how much disk a server's pool can take. Each
image is still capped at 10 MB, and the VM has 35 GB free against the 149 MB this migration needs,
so there's a lot of headroom — but it is headroom, not a guarantee. `deploy/README.md` now says to
keep an eye on it with `du -sh` instead of quoting a worst case that no longer exists.

## Changes

- `src/banner/store.ts` — dropped `MAX_IMAGES_PER_GUILD` and `GuildImageLimitReached`, and the
  count check in `add()`.
- `src/commands/banner.ts` — dropped the limit branch (which makes the `try/catch` around
  `store.add` unnecessary, so that's gone too), the "Up to 100 per server" line in `-banner`'s help,
  and the `N/100` in the `-banner list` title, now just `banner images (N)`.
- `deploy/README.md` — the ops note said "capped at 100 per guild (~200 MB worst case)".

## Testing

294 tests still pass. The two cap tests were inverted rather than deleted, so the new behaviour is
asserted rather than merely unguarded:

- `store.test.ts` — `keeps accepting images past the old 100-image ceiling` adds 120 and expects 120
- `banner.test.ts` — `accepts an image on a server that is already past 100` seeds 100 and expects
  the reply `added as number 101`

## Versioning

2.5.0 → **2.6.0** (minor) — user-visible behaviour change.