### PR TITLE
feat(ops): pull prod banner images to a local archive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,15 @@ LASTFM_API_KEY=
 # Database
 DB_PATH=.data/feed1.sqlite
 
-# Optional: prod host for `npm run db:pull` (user@host; bare host assumes ubuntu@)
+# Optional: prod host for `npm run db:pull` / `npm run img:pull` (user@host; bare
+# host assumes ubuntu@)
 # Prefer an ssh config alias over a raw IP — the pull uses plain `ssh`, so the
 # key has to come from ~/.ssh/config or the agent, not from here.
 PROD_SSH_HOST=
+
+# Optional: where the banner pool lives on prod. The bot derives it from
+# dirname(DB_PATH), so only set this if prod's layout differs from the default.
+PROD_BANNERS_PATH=
 
 # Optional: comma-separated guildId:pageCap overrides for chart queue depth
 # e.g. 671074176622264320:0 means unlimited pages for that guild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ npm run typecheck  # tsc --noEmit
 npm run lint       # eslint src test scripts
 npm run smoke      # drives a running dev bot over real Discord
 npm run db:pull    # read-only prod snapshot -> .data/prod/ (see deploy/README.md)
+npm run img:pull   # prod banner images -> .data/prod/banners{,.zip}; pair it with db:pull
 ```
 
 Tests use `nock` with net access disabled and the fakes in `test/helpers/fake.ts` (in-memory SQLite,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -131,6 +131,34 @@ database. The pull instead opens prod **read-only** on the box and uses `VACUUM 
 safe against the running bot and physically cannot write to it; what comes down is a standalone
 file with no WAL.
 
+### Backing up the banner images
+
+```sh
+npm run img:pull                       # same host resolution as db:pull
+npm run img:pull -- ubuntu@<vm-ip>
+```
+
+Lands the whole `banners/` tree at `.data/prod/banners/` plus `.data/prod/banners.zip` (both
+gitignored). The zip is for carrying elsewhere — these are PNG/JPEG, so it compresses by well
+under a percent; the point is one file, not a smaller one.
+
+**`db:pull` and `img:pull` are a recovery pair, not alternatives.** The files on disk are named by
+content hash, so on their own they're an unlabelled pile of bytes — it's the `banner_images` rows
+that say which guild each belongs to, what its id is, and who added it. Restoring a pool needs
+both artifacts from around the same time.
+
+Two behaviours worth knowing:
+
+- **The pull is additive — it never deletes.** `rsync` runs without `--delete` on purpose: this is
+  the only copy of these files, so a pull that happens to run after an accidental
+  `-banner remove all` must not carry that deletion into the backup. The local tree can therefore
+  hold images prod no longer has.
+- **Every file is verified against its own name.** `store.add()` writes bytes straight to their
+  final path rather than renaming into place, so an image being added mid-pull can be copied
+  half-written. Since the filename *is* the sha256, the pull re-hashes each file and compares.
+  Failures are renamed to `.corrupt` (kept, not deleted), left out of the zip, and reported with a
+  non-zero exit — re-run to refetch them. Zero verification failures is the normal result.
+
 ## Discord portal checklist (once per bot application)
 
 - Bot → Privileged Gateway Intents: enable **Server Members Intent** and
@@ -145,7 +173,8 @@ file with no WAL.
   `predeploy_*.sqlite` snapshot per deploy. All snapshots use `VACUUM INTO`.
 - `-banner` images live in `/opt/feed1/.data/banners/<guildId>/`, uncapped — each is at most 10 MB,
   so growth is worth an occasional `du -sh`. The deploy's `rsync --delete` excludes `.data`,
-  so they survive merges — but **backups only cover the SQLite file, not these**. Losing the
-  volume means re-adding banners by hand; the rows in `banner_images` will point at files that
-  are gone, and rotation skips them rather than failing.
+  so they survive merges — but **the automated backups only cover the SQLite file, not these**.
+  Pull them by hand with `npm run img:pull` (below). Without a pull, losing the volume means
+  re-adding banners by hand; the rows in `banner_images` will point at files that are gone, and
+  rotation skips them rather than failing.
 - The whole VM is disposable: a fresh one needs only provision.sh + .env + repo secrets update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "smoke": "tsx test/live/smoke.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:pull": "bash scripts/db-pull.sh"
+    "db:pull": "bash scripts/db-pull.sh",
+    "img:pull": "bash scripts/img-pull.sh"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/img-pull.sh
+++ b/scripts/img-pull.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Pull the production banner image pool to .data/prod/ — a tree plus a zip of it.
+#
+#   npm run img:pull                 # host from PROD_SSH_HOST in .env
+#   npm run img:pull -- ubuntu@1.2.3.4
+#
+# These images are in no other backup: the 12-hourly VACUUM INTO covers the SQLite
+# file only, and the deploy's rsync excludes .data entirely. Restoring a pool needs
+# BOTH this and a db:pull — the files are named by content hash, so the
+# banner_images rows are what map them back to guilds and ids.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_APP="${PROD_APP_DIR:-/opt/feed1}"
+# the bot derives this from dirname(DB_PATH); override if prod's layout ever moves
+REMOTE_BANNERS="${PROD_BANNERS_PATH:-$REMOTE_APP/.data/banners}"
+DEST_DIR="$REPO_ROOT/.data/prod/banners"
+DEST_ZIP="$REPO_ROOT/.data/prod/banners.zip"
+
+HOST="${1:-${PROD_SSH_HOST:-}}"
+if [[ -z "$HOST" && -f "$REPO_ROOT/.env" ]]; then
+  # `|| true`: a .env without the key must reach the message below, not trip pipefail
+  HOST="$(grep -E '^PROD_SSH_HOST=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)"
+  HOST="${HOST//[\"\' $'\r']/}"
+fi
+if [[ -z "$HOST" ]]; then
+  echo "no host: pass one (npm run img:pull -- ubuntu@1.2.3.4) or set PROD_SSH_HOST in .env" >&2
+  exit 1
+fi
+[[ "$HOST" == *@* ]] || HOST="ubuntu@$HOST"
+
+# fail with something readable rather than letting rsync error on a missing path
+ssh "$HOST" bash -s -- "$REMOTE_BANNERS" <<'REMOTE'
+set -euo pipefail
+DIR="$1"
+[[ -d "$DIR" ]] || { echo "no banner directory at $DIR" >&2; exit 1; }
+[[ -n "$(find "$DIR" -type f -print -quit)" ]] || { echo "no banner images in $DIR" >&2; exit 1; }
+REMOTE
+
+echo "pulling $HOST:$REMOTE_BANNERS ..."
+mkdir -p "$DEST_DIR"
+# no --delete: this is the only copy of these files, so a pull that follows an
+# accidental `-banner remove all` must not propagate the deletion into the backup
+rsync -az --stats "$HOST:$REMOTE_BANNERS/" "$DEST_DIR/" | tail -3
+
+# store.add() writes bytes straight to their final path, so a concurrent `-banner add`
+# can be captured mid-write. The filename is the sha256 of the contents, so a torn
+# file is detectable locally with no remote cooperation.
+echo "verifying ..."
+corrupt=0
+total=0
+bytes=0
+while IFS= read -r file; do
+  total=$((total + 1))
+  bytes=$((bytes + $(wc -c <"$file")))
+  expected="$(basename "$file")"
+  expected="${expected%.*}"
+  actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+  if [[ "$actual" != "$expected" ]]; then
+    corrupt=$((corrupt + 1))
+    echo "  CORRUPT ${file#"$DEST_DIR/"}" >&2
+    # rsync matches on size+mtime, so a same-size corruption would be skipped on every
+    # later run. Move it aside so the next pull refetches — renamed, not deleted:
+    # prod's copy may be gone too, and a bad copy still beats none.
+    mv "$file" "$file.corrupt"
+  fi
+done < <(find "$DEST_DIR" -type f ! -name '*.corrupt')
+
+rm -f "$DEST_ZIP.part"
+(cd "$DEST_DIR" && zip -r -q -X "$DEST_ZIP.part" . -x '*.corrupt') >/dev/null
+mv "$DEST_ZIP.part" "$DEST_ZIP"
+
+guilds="$(find "$DEST_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+# apparent size, not `du` — du reports block allocation, which for one big archive
+# on APFS reads ~7% above the real byte count and makes the zip look bloated
+human() { awk -v b="$1" 'BEGIN { printf "%.0f MB", b / 1048576 }'; }
+echo "pulled $total file(s) across $guilds guild(s) — $(human "$bytes") tree, $(human "$(wc -c <"$DEST_ZIP")") zip"
+echo "  ${DEST_DIR#"$REPO_ROOT/"}"
+echo "  ${DEST_ZIP#"$REPO_ROOT/"}"
+
+if (( corrupt > 0 )); then
+  echo "$corrupt file(s) failed verification and were left out of the zip — re-run to refetch" >&2
+  exit 1
+fi
+echo "all $total file(s) match their content hash"


### PR DESCRIPTION
## What & why

`-banner` images are the one thing on the VM with no backup. The 12-hourly `VACUUM INTO` covers the
SQLite file only, and the deploy's `rsync --delete` excludes `.data` entirely — so the 218 images in
Feel's pool exist on exactly one disk. `img:pull` gives them a local copy.

```sh
npm run img:pull                       # host from PROD_SSH_HOST, same as db:pull
npm run img:pull -- ubuntu@<vm-ip>
```

Lands `.data/prod/banners/` plus `.data/prod/banners.zip`, both gitignored.

## Why rsync-then-zip locally

**There is no `zip` on the VM** — only `tar`/`gzip`. Installing one would mean `apt install` on a box
that also hosts an unrelated Usenet stack, which is a bad trade to save a step. (`db:pull` hit the
same shape of problem with `sqlite3` and routed around it the same way.)

Archiving locally turns out to be the better design anyway: rsync moves only what changed, so a
re-pull of a 150 MB pool transfers almost nothing, where a remote tarball would resend everything
every time. The tree is the browsable working copy; the zip is the portable artifact. Compression
isn't the point — these are PNG/JPEG, so the zip comes in about half a percent under the raw bytes.

## Two behaviours that are deliberate

**The pull never deletes.** `rsync` runs without `--delete` on purpose. This is the only copy of
these files, so a pull that happens to run after an accidental `-banner remove all` must not carry
that deletion into the backup. The cost — the tree can retain images prod no longer has — is the
right direction to err for a backup.

**Every file is verified against its own name.** `store.add()` writes bytes straight to their final
path rather than renaming into place (`src/banner/store.ts:78`), so an image added mid-pull can be
copied half-written under a valid-looking `<sha256>.<ext>`. Since the filename *is* the digest, the
check is a local re-hash — no remote cooperation, no stopping the bot to take a backup. Failures are
renamed to `.corrupt` (kept, not deleted — prod's copy might be gone too), left out of the zip, and
reported with a non-zero exit. The rename matters: rsync matches on size+mtime, so a same-size
corruption would otherwise be skipped forever instead of refetched.

## Recovery is both pulls, not one

Documented in `deploy/README.md`: the files are named by content hash, so alone they're an
unlabelled pile of bytes. It's the `banner_images` rows that map them to guilds, ids and uploaders.
A real backup is `db:pull` **and** `img:pull` from around the same time.

## Notes

- `PROD_BANNERS_PATH` overrides the remote path, mirroring `db-pull.sh`'s `PROD_APP_DIR`/`PROD_DB_PATH`.
  The default is right today, but the bot *derives* its banner root from `dirname(DB_PATH)`, so
  hard-coding it would be a lie.
- `db-pull.sh` is deliberately untouched. Factoring the shared host-resolution block into a lib was
  considered and rejected — it modifies the tool you need during an incident, has no automated
  coverage, and serves one new caller.

## Testing

No vitest suite, consistent with `db-pull.sh` (which has none). Verified against prod:

- Full pull: 218 files, 1 guild, all 218 match their content hash; `unzip -t` clean.
- **Corruption path**: flipped bytes in a pulled file without changing size or mtime, so rsync
  wouldn't silently repair it. The run flagged it, excluded it from the zip (218 entries, down from
  219), and exited 1; the next run refetched it and returned to all-218-verified.
- **Guard**: `PROD_BANNERS_PATH=/opt/feed1/.data/nope` exits 1 with `no banner directory at ...`
  instead of an opaque rsync error.
- `shellcheck` clean — it caught a real bug during development: `<<'REMOTE' </dev/null` had two
  competing stdin redirections, which meant the remote guard was silently never executing.
- lint, typecheck, 294 tests green.

## Versioning

2.6.0 → **2.6.1** (patch), matching the `db:pull` precedent — that PR shipped the same class of
change (new npm script, shell script, `.env.example` key, docs) as `2.3.0 → 2.3.1`.