### PR TITLE
feat(db): tally command usage per user and per command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ tested without Discord or HTTP.
   the scheduler polls for due rows. Catch-up is deliberately non-accumulating: a guild that was due 200
   times during an outage rotates **once** and reschedules from now. `next_run_at` also advances after a
   *failed* rotation, or a broken guild would be retried every tick forever.
+- **Command counters are two views of one number.** `users.command_count` is a denormalised total
+  and `command_usage` holds the per-command breakdown; `SUM(command_usage.count)` for a user equals
+  their `command_count`. `Router.recordUse` writes both in a single transaction and skips both when
+  the caller has no `users` row, so the two can't drift. Counting happens *before* `command.run`, so
+  these are attempts, not successes, and cooldown-suppressed messages don't count.
 - Artist crown recalculation is queued to the DB and drained by a worker, not done inline. The
   **album** crown is the exception: `-fm` settles it inline after its rank scans, because the footer
   gif has to say whether the caller holds the crown. The queued album job is enqueued first as the

--- a/drizzle/0004_add_command_counters.sql
+++ b/drizzle/0004_add_command_counters.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `command_usage` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL,
+	`command_name` text NOT NULL,
+	`count` integer DEFAULT 0 NOT NULL,
+	`last_used` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `command_usage_user_command` ON `command_usage` (`user_id`,`command_name`);--> statement-breakpoint
+ALTER TABLE `users` ADD `command_count` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,859 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "228df7be-1e8c-403b-ad0b-5a1f275a422b",
+  "prevId": "c231f220-f0d7-4401-8248-2cda69055c8b",
+  "tables": {
+    "album_crowns": {
+      "name": "album_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_plays": {
+          "name": "album_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "album_url": {
+          "name": "album_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "album_crowns_guild_artist_album": {
+          "name": "album_crowns_guild_artist_album",
+          "columns": [
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artist_crowns": {
+      "name": "artist_crowns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_plays": {
+          "name": "artist_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_plays": {
+          "name": "server_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "server_listeners": {
+          "name": "server_listeners",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "artist_url": {
+          "name": "artist_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_img_url": {
+          "name": "artist_img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "artist_crowns_guild_artist": {
+          "name": "artist_crowns_guild_artist",
+          "columns": [
+            "guild_id",
+            "artist_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_configs": {
+      "name": "banner_configs",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_image_id": {
+          "name": "last_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "banner_configs_next_run": {
+          "name": "banner_configs_next_run",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_images": {
+      "name": "banner_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "animated": {
+          "name": "animated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "banner_images_guild_sha": {
+          "name": "banner_images_guild_sha",
+          "columns": [
+            "guild_id",
+            "sha256"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "command_usage": {
+      "name": "command_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_name": {
+          "name": "command_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "command_usage_user_command": {
+          "name": "command_usage_user_command",
+          "columns": [
+            "user_id",
+            "command_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_audit": {
+      "name": "crown_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prev_owner_id": {
+          "name": "prev_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_owner_id": {
+          "name": "new_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_plays": {
+          "name": "prev_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_plays": {
+          "name": "new_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crown_jobs": {
+      "name": "crown_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "crown_jobs_dedupe": {
+          "name": "crown_jobs_dedupe",
+          "columns": [
+            "kind",
+            "guild_id",
+            "artist_name",
+            "album_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "disables": {
+      "name": "disables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command_name": {
+          "name": "command_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "disables_guild_command": {
+          "name": "disables_guild_command",
+          "columns": [
+            "guild_id",
+            "command_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notif_prefs": {
+      "name": "notif_prefs",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_win": {
+          "name": "on_win",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "on_loss": {
+          "name": "on_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_timings": {
+      "name": "scan_timings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ms": {
+          "name": "ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rym_username": {
+          "name": "rym_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rym_per_page": {
+          "name": "rym_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rym_max": {
+          "name": "rym_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wish_max": {
+          "name": "wish_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag_max": {
+          "name": "tag_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chart_url": {
+          "name": "chart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "columns": [
+            "discord_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786729265124,
       "tag": "0003_add_banner_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1787240552960,
+      "tag": "0004_add_command_counters",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -1,8 +1,8 @@
 import type { Message } from 'discord.js';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { AppContext } from './command.js';
 import { disabledScope } from './disables.js';
-import { users } from '../db/schema.js';
+import { commandUsage, users } from '../db/schema.js';
 
 const COOLDOWN_MS = 2000;
 
@@ -47,11 +47,7 @@ export class Router {
     const last = this.lastUse.get(message.author.id) ?? 0;
     if (now - last < COOLDOWN_MS) return;
     this.lastUse.set(message.author.id, now);
-    this.app.db
-      .update(users)
-      .set({ lastUsed: new Date() })
-      .where(eq(users.discordUserId, message.author.id))
-      .run();
+    this.recordUse(message.author.id, command.name);
 
     try {
       await command.run({ app: this.app, message, args: parts });
@@ -59,5 +55,26 @@ export class Router {
       await errors.report(error, `command ${command.name}`);
       await message.reply(snippets.error).catch(() => undefined);
     }
+  }
+
+  private recordUse(discordUserId: string, commandName: string): void {
+    const usedAt = new Date();
+    this.app.db.transaction((tx) => {
+      const { changes } = tx
+        .update(users)
+        .set({ lastUsed: usedAt, commandCount: sql`${users.commandCount} + 1` })
+        .where(eq(users.discordUserId, discordUserId))
+        .run();
+      // Unregistered callers have no users row, and counting them in the
+      // breakdown alone would break the SUM(count) == command_count invariant.
+      if (changes === 0) return;
+      tx.insert(commandUsage)
+        .values({ userId: discordUserId, commandName, count: 1, lastUsed: usedAt })
+        .onConflictDoUpdate({
+          target: [commandUsage.userId, commandUsage.commandName],
+          set: { count: sql`${commandUsage.count} + 1`, lastUsed: usedAt },
+        })
+        .run();
+    });
   }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,7 +19,26 @@ export const users = sqliteTable('users', {
   chartUrl: text('chart_url'),
   createdAt: createdAt(),
   lastUsed: integer('last_used', { mode: 'timestamp_ms' }),
+  commandCount: integer('command_count').notNull().default(0),
 });
+
+/**
+ * Per-command tallies. `SUM(count)` for a user equals that user's
+ * `users.command_count` — the router writes both in one transaction.
+ */
+export const commandUsage = sqliteTable(
+  'command_usage',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    userId: text('user_id').notNull(),
+    /** canonical command name, never an alias */
+    commandName: text('command_name').notNull(),
+    count: integer('count').notNull().default(0),
+    lastUsed: integer('last_used', { mode: 'timestamp_ms' }).notNull(),
+    createdAt: createdAt(),
+  },
+  (t) => [uniqueIndex('command_usage_user_command').on(t.userId, t.commandName)],
+);
 
 export const artistCrowns = sqliteTable(
   'artist_crowns',

--- a/test/core/router.test.ts
+++ b/test/core/router.test.ts
@@ -107,6 +107,10 @@ describe('Router', () => {
 
     const row = app.db.select().from(schema.users).get();
     expect(row?.lastUsed).toEqual(usedAt);
+    expect(row?.commandCount).toBe(1);
+    expect(app.db.select().from(schema.commandUsage).all()).toMatchObject([
+      { userId: 'user-1', commandName: 'fm', count: 1, lastUsed: usedAt },
+    ]);
   });
 
   it('does not insert a user row when an unregistered user runs a command', async () => {
@@ -118,6 +122,7 @@ describe('Router', () => {
 
     expect(cmd.calls).toBe(1);
     expect(app.db.select().from(schema.users).all()).toEqual([]);
+    expect(app.db.select().from(schema.commandUsage).all()).toEqual([]);
   });
 
   it('does not update last use for cooldown-suppressed messages', async () => {
@@ -141,6 +146,45 @@ describe('Router', () => {
     const row = app.db.select().from(schema.users).get();
     expect(cmd.calls).toBe(1);
     expect(row?.lastUsed).toEqual(firstUse);
+    expect(row?.commandCount).toBe(1);
+    expect(app.db.select().from(schema.commandUsage).all()).toMatchObject([
+      { commandName: 'fm', count: 1 },
+    ]);
+  });
+
+  it('tallies each command under its canonical name and keeps the total in step', async () => {
+    const fm = testCommand();
+    const wk = testCommand({ name: 'wk', aliases: [] });
+    const app = makeFakeApp([fm, wk]);
+    app.db.insert(schema.users).values({ discordUserId: 'user-1', lastfmUsername: 'lfm1' }).run();
+    const router = new Router(app);
+    const start = new Date('2026-08-20T12:00:00.000Z');
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(start);
+      await router.handle(makeFakeMessage({ content: '&fm' }).message);
+      vi.setSystemTime(new Date(start.getTime() + 5000));
+      await router.handle(makeFakeMessage({ content: '&f' }).message);
+      vi.setSystemTime(new Date(start.getTime() + 10000));
+      await router.handle(makeFakeMessage({ content: '&wk' }).message);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const user = app.db.select().from(schema.users).get();
+    expect(user?.commandCount).toBe(3);
+
+    const usage = app.db
+      .select()
+      .from(schema.commandUsage)
+      .orderBy(schema.commandUsage.commandName)
+      .all();
+    expect(usage.map((r) => [r.commandName, r.count])).toEqual([
+      ['fm', 2],
+      ['wk', 1],
+    ]);
+    expect(usage.reduce((sum, r) => sum + r.count, 0)).toBe(user?.commandCount);
   });
 
   it('blocks owner-only commands for non-owners', async () => {


### PR DESCRIPTION
## What

Starts counting command runs, at two granularities:

- **`users.command_count`** — a denormalised running total per user, sitting next to the
  existing `last_used`.
- **`command_usage`** — a new table keyed uniquely on `(user_id, command_name)` holding the
  per-command breakdown, plus its own `last_used` so "when did you last use `-wk`" is
  answerable.

Both are written by `Router.recordUse`, from the same `UPDATE users` that already recorded
`last_used` — so there is no additional query on the hot path, and the increments are done
as `count = count + 1` in SQLite rather than read-modify-write in JS, making them atomic
under concurrent commands.

The two views are kept consistent by construction: they are written inside a single
transaction, and both are skipped when the caller has no `users` row. That makes
`SUM(command_usage.count) = users.command_count` a real invariant rather than a hope, and a
test asserts it. Tallies are keyed on the **canonical** command name, so `-f` counts as `fm`.

Semantics are inherited from `last_used` deliberately: counting happens before
`command.run()`, so these are *attempts, not successes*, and cooldown-suppressed messages
don't count. Both facts are documented in `CLAUDE.md`.

Nothing displays these numbers yet — this PR only starts collecting them, so there is no
user-visible change and no risk to the byte-compatible legacy output. Patch bump to 2.6.3.

## Why

`last_used` answers "is this user still around" but not "how much do they actually use the
bot, and which commands". Collecting both now means there is history to look at whenever a
stats command gets built; a total added later could never be split into per-command counts
retroactively, which is why the breakdown table lands in the same change.

## Notes

`ALTER TABLE users ADD command_count integer DEFAULT 0 NOT NULL` backfills existing rows
with `0`, so the migration is safe on the production DB — existing users simply start
counting from zero rather than from their true historical total.