### PR TITLE
feat(changelog): add CHANGELOG.md and a paged -changelog command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,9 @@ jobs:
         run: |
           mkdir -p stage
           cp -r dist drizzle images deploy package.json package-lock.json NotoSansCJKjp-Regular.otf stage/
+          # Guarded, not joined into the cp above: rolling back to any tag cut
+          # before this file existed must not abort the staging step.
+          if [ -f CHANGELOG.md ]; then cp CHANGELOG.md stage/; fi
           ssh -i ~/.ssh/id_ed25519 "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
             "mkdir -p '${{ secrets.DEPLOY_PATH }}/incoming'"
           rsync -az --delete -e "ssh -i ~/.ssh/id_ed25519" \
@@ -185,5 +188,11 @@ jobs:
             exit 1
           fi
 
-          gh release create "$tag" --title "$tag" --generate-notes --target "${{ github.sha }}"
+          npx tsx scripts/changelogSection.ts "$version" > /tmp/notes.md || true
+          if [ -s /tmp/notes.md ]; then
+            gh release create "$tag" --title "$tag" --notes-file /tmp/notes.md --target "${{ github.sha }}"
+          else
+            echo "::warning::no CHANGELOG.md entry for $version"
+            gh release create "$tag" --title "$tag" --generate-notes --target "${{ github.sha }}"
+          fi
           echo "released $tag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+Newest release first. Every merge to `main` adds an entry here in the same commit that bumps
+`version` in `package.json` — see [VERSIONING.md](VERSIONING.md) for which number to pick.
+`-changelog` reads this file from inside Discord, and each GitHub release takes its notes from the
+matching section.
+
+Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
+people using the bot rather than for the diff.
+
+## [2.6.3] - 2026-08-20
+
+- Command runs are tallied per user and per command.
+
+## [2.6.2] - 2026-08-20
+
+- Dropped an unused image asset from the repo.
+
+## [2.6.1] - 2026-08-14
+
+- `npm run img:pull` copies the production banner images down to a local archive.
+
+## [2.6.0] - 2026-08-14
+
+- The banner image pool is no longer capped per server.
+
+## [2.5.0] - 2026-08-14
+
+- `-banner` builds a pool of images and rotates the server banner through them on an interval you
+  choose. Images live on the bot's own disk, so nothing depends on a third-party host staying up.
+
+## [2.4.0] - 2026-08-14
+
+- The bot records when each user last ran a command.
+
+## [2.3.4] - 2026-08-05
+
+- `-rand` and `-wrand` show one pick per page.
+
+## [2.3.3] - 2026-08-05
+
+- Renamed the crowns table to `artist_crowns`. No visible change.
+
+## [2.3.2] - 2026-08-05
+
+- Documented that `db:pull` needs an ssh config entry.
+
+## [2.3.1] - 2026-08-05
+
+- `npm run db:pull` takes a read-only snapshot of the production database for local querying.
+
+## [2.3.0] - 2026-08-03
+
+- `-fm` settles the album crown inline, so the footer gif stops guessing at who holds it.
+
+## [2.2.1] - 2026-08-03
+
+- Turned off commit and PR attribution at the repo level.
+
+## [2.2.0] - 2026-08-03
+
+- `-wk` and `-plays` fall back to your last scrobbled track when nothing is playing.
+- Added VERSIONING.md as the single source of truth for version bumps.
+
+## [2.1.0] - 2026-08-03
+
+- `package.json` is the source of truth for releases; each merge tags and publishes that version.
+- A release tag can be redeployed as a rollback, guarded against database schema drift.
+
+## [2.0.0] - 2026-07-31
+
+- Rewrote the bot as feed1: TypeScript on discord.js v14, with SQLite through Drizzle and
+  migrations applied at startup. The pre-rewrite JavaScript is preserved at the `legacy` tag.
+- `-fm` shows artist ranks alongside album ranks.
+- `-logs` reads recent bot logs from journald (owner only).
+- Artist and album crowns key on Last.fm's canonical names, so spelling variants no longer split a
+  crown.
+- `-wk` uses the member cache instead of a gateway fetch, which stopped it hitting rate limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ matching section.
 Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
 people using the bot rather than for the diff.
 
+## [2.7.0] - 2026-08-20
+
+- `-changelog` (alias `-changes`) pages through this file in Discord, newest release first.
+- GitHub release notes now come from the changelog entry for that version when one exists.
+
 ## [2.6.3] - 2026-08-20
 
 - Command runs are tallied per user and per command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ tested without Discord or HTTP.
   **album** crown is the exception: `-fm` settles it inline after its rank scans, because the footer
   gif has to say whether the caller holds the crown. The queued album job is enqueued first as the
   failure path and deleted once the inline scan succeeds.
+- `-changelog` reads `CHANGELOG.md` from the repo root at runtime (`src/commands/changelog.ts`), so
+  it must stay in the deploy's staged path list alongside `dist`, `drizzle`, etc.
 
 ## Migrations
 
@@ -82,4 +84,5 @@ VM, DB backup, `systemctl restart feed1`. CI (typecheck, lint, test, build) runs
 **Every PR merged to `main` must bump `version` in `package.json`** — docs and CI-only changes
 included, as a patch. The merge tags that version and cuts a release; an unchanged version leaves
 the deploy fine but turns the run red. Read [VERSIONING.md](VERSIONING.md) before choosing the
-number; it owns the rules, and `deploy/README.md` covers rollback mechanics.
+number; it owns the rules, and `deploy/README.md` covers rollback mechanics. The bump commit also
+carries a matching `CHANGELOG.md` entry, which becomes the GitHub release body.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ npm run dev
 GitHub Actions deploys `main` to an Oracle Cloud free-tier VM over SSH. Bump `version` in
 `package.json` as part of your PR; each merge tags that version and publishes a
 [GitHub Release](../../releases). Every merge bumps — see [VERSIONING.md](VERSIONING.md) for which
-number and why, and [deploy/README.md](deploy/README.md) for the one-time setup and rollbacks.
+number and why, and [deploy/README.md](deploy/README.md) for the one-time setup and rollbacks. Add
+a matching entry to [CHANGELOG.md](CHANGELOG.md) in the same commit.
 
 ## Commands
 
@@ -40,3 +41,5 @@ Run `-help` for the generated list; `-help <command>` for details, aliases, and 
 through the pool one image at a time. Images are stored on the bot's own disk, so nothing
 depends on a third-party host staying up. Needs a server at boost level 1 or higher (Discord's
 requirement for having a banner at all), and Manage Server for anything that changes state.
+
+`-changelog` (alias `-changes`) pages through [CHANGELOG.md](CHANGELOG.md) from inside Discord.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -25,10 +25,12 @@ a tag that already exists**, so a merge without a bump turns `main` red; and one
 keeps releases and merge commits one-to-one, which is what makes `-botinfo` a useful answer to
 "what's actually running?".
 
-Put the bump in its own final commit so it's easy to see and easy to redo after a rebase:
+Put the bump in its own final commit so it's easy to see and easy to redo after a rebase, together
+with the changelog entry (below) for the same version:
 
 ```sh
 npm version 2.3.0 --no-git-tag-version   # updates package.json + package-lock.json
+# add a "## [2.3.0] - YYYY-MM-DD" entry to CHANGELOG.md
 git commit -am "chore(release): 2.3.0"
 ```
 
@@ -61,3 +63,11 @@ rolling back past a migration is refused unless forced. A change that adds a mig
 rollback boundary, which is worth keeping in mind when deciding how much to put in one PR.
 
 Mechanics, the migration guard, and DB restores: [deploy/README.md](deploy/README.md).
+
+## The changelog
+
+The version bump's final commit carries a matching top entry in
+[CHANGELOG.md](CHANGELOG.md): `## [x.y.z] - YYYY-MM-DD` followed by one `-` bullet per
+user-visible change, newest release first. It ships with the deploy and is what `-changelog` shows
+in Discord. The release step also prefers it as the GitHub release body, falling back to
+`--generate-notes` with a CI warning when a version has no entry.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -68,6 +68,9 @@ Mechanics, the migration guard, and DB restores: [deploy/README.md](deploy/READM
 
 The version bump's final commit carries a matching top entry in
 [CHANGELOG.md](CHANGELOG.md): `## [x.y.z] - YYYY-MM-DD` followed by one `-` bullet per
-user-visible change, newest release first. It ships with the deploy and is what `-changelog` shows
-in Discord. The release step also prefers it as the GitHub release body, falling back to
-`--generate-notes` with a CI warning when a version has no entry.
+user-visible change, newest release first. A release with nothing user-visible (a docs- or CI-only
+patch bump) still gets an entry, with a bullet naming what actually changed (e.g. "Internal: docs
+and CI only.") — every released version should appear so `-changelog` has no gaps. It ships with
+the deploy and is what `-changelog` shows in Discord. The release step also prefers it as the
+GitHub release body, falling back to `--generate-notes` with a CI warning when a version has no
+entry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.6.3",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/changelogSection.ts
+++ b/scripts/changelogSection.ts
@@ -1,0 +1,24 @@
+// CI-only: prints the release-notes section for a version. Lives outside src/
+// so it never lands in dist/.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import { sectionFor } from '../src/commands/changelogFormat.js';
+
+export { sectionFor };
+
+function main(): void {
+  const version = process.argv[2];
+  if (!version) return;
+  let markdown: string;
+  try {
+    markdown = readFileSync('CHANGELOG.md', 'utf8');
+  } catch {
+    return;
+  }
+  const section = sectionFor(markdown, version);
+  if (section) process.stdout.write(`${section}\n`);
+}
+
+const entry = process.argv[1];
+if (entry && resolve(entry) === fileURLToPath(import.meta.url)) main();

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -8,15 +8,10 @@ import { changelogPages, parseChangelog } from './changelogFormat.js';
 
 const DEFAULT_PATH = fileURLToPath(new URL('../../CHANGELOG.md', import.meta.url));
 
-let cached: string | null = null;
-
 /** `path` is only for testing the failure branch against a nonexistent file. */
 export function readChangelogFile(path: string = DEFAULT_PATH): string | null {
-  if (cached !== null) return cached;
   try {
-    const content = readFileSync(path, 'utf8');
-    cached = content;
-    return content;
+    return readFileSync(path, 'utf8');
   } catch {
     return null;
   }

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { EmbedBuilder } from 'discord.js';
+import type { Command } from '../core/command.js';
+import { sendPaginatedEmbed } from '../core/paginate.js';
+import { readPackageVersion } from '../core/version.js';
+import { changelogPages, parseChangelog } from './changelogFormat.js';
+
+const DEFAULT_PATH = fileURLToPath(new URL('../../CHANGELOG.md', import.meta.url));
+
+let cached: string | null = null;
+
+/** `path` is only for testing the failure branch against a nonexistent file. */
+export function readChangelogFile(path: string = DEFAULT_PATH): string | null {
+  if (cached !== null) return cached;
+  try {
+    const content = readFileSync(path, 'utf8');
+    cached = content;
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+const changelog: Command = {
+  name: 'changelog',
+  aliases: ['changes'],
+  description: 'Shows what changed release by release.',
+  usage: 'changelog',
+  guildOnly: false,
+  async run({ message }) {
+    const markdown = readChangelogFile();
+    if (markdown === null) return message.reply(`couldn't read the changelog.`);
+
+    const entries = parseChangelog(markdown);
+    const pages = changelogPages(entries);
+    const embeds = pages.map((description, i) =>
+      new EmbedBuilder()
+        .setTitle('feed1 changelog')
+        .setColor(message.member?.displayColor ?? null)
+        .setDescription(description)
+        .setFooter({
+          text: `page no. ${i + 1}/${pages.length} | v${readPackageVersion()} is live`,
+          iconURL: message.author.displayAvatarURL(),
+        }),
+    );
+    return sendPaginatedEmbed(message, embeds, message.author.id);
+  },
+};
+
+export const changelogCommands: Command[] = [changelog];

--- a/src/commands/changelogFormat.ts
+++ b/src/commands/changelogFormat.ts
@@ -25,15 +25,22 @@ export function parseChangelog(markdown: string): ChangelogEntry[] {
     if (!current) continue;
     const line = raw.trim();
     if (line.length === 0) continue;
-    current.lines.push(line);
+    if (!line.startsWith('-') && current.lines.length > 0) {
+      current.lines[current.lines.length - 1] += ` ${line}`;
+    } else {
+      current.lines.push(line);
+    }
   }
 
   return entries;
 }
 
+function entryHeader(entry: ChangelogEntry): string {
+  return entry.date ? `**v${entry.version}** — ${entry.date}` : `**v${entry.version}**`;
+}
+
 function renderEntry(entry: ChangelogEntry): string {
-  const header = entry.date ? `**v${entry.version}** — ${entry.date}` : `**v${entry.version}**`;
-  return [header, ...entry.lines].join('\n');
+  return [entryHeader(entry), ...entry.lines].join('\n');
 }
 
 /** Greedy-packs whole entries into pages; an over-budget entry splits at line boundaries. */
@@ -52,7 +59,7 @@ export function changelogPages(entries: ChangelogEntry[], budget = 1800): string
     const rendered = renderEntry(entry);
     if (rendered.length > budget) {
       flush();
-      const header = entry.date ? `**v${entry.version}** — ${entry.date}` : `**v${entry.version}**`;
+      const header = entryHeader(entry);
       let chunk = header;
       for (const line of entry.lines) {
         const candidate = `${chunk}\n${line}`;

--- a/src/commands/changelogFormat.ts
+++ b/src/commands/changelogFormat.ts
@@ -1,0 +1,88 @@
+export interface ChangelogEntry {
+  version: string;
+  date: string | null;
+  lines: string[];
+}
+
+const HEADING = /^##\s*\[?(\d+\.\d+\.\d+)\]?\s*[-–—]?\s*(\S+)?/;
+
+/** Scans `## [x.y.z] - date` headings; preserves file order (authored newest-first). */
+export function parseChangelog(markdown: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  let current: ChangelogEntry | null = null;
+
+  for (const raw of markdown.split('\n')) {
+    if (raw.startsWith('## ') || raw.startsWith('##\t')) {
+      const match = HEADING.exec(raw);
+      if (match) {
+        current = { version: match[1]!, date: match[2] ?? null, lines: [] };
+        entries.push(current);
+        continue;
+      }
+      current = null;
+      continue;
+    }
+    if (!current) continue;
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    current.lines.push(line);
+  }
+
+  return entries;
+}
+
+function renderEntry(entry: ChangelogEntry): string {
+  const header = entry.date ? `**v${entry.version}** — ${entry.date}` : `**v${entry.version}**`;
+  return [header, ...entry.lines].join('\n');
+}
+
+/** Greedy-packs whole entries into pages; an over-budget entry splits at line boundaries. */
+export function changelogPages(entries: ChangelogEntry[], budget = 1800): string[] {
+  const pages: string[] = [];
+  let current = '';
+
+  const flush = () => {
+    if (current.length > 0) {
+      pages.push(current);
+      current = '';
+    }
+  };
+
+  for (const entry of entries) {
+    const rendered = renderEntry(entry);
+    if (rendered.length > budget) {
+      flush();
+      const header = entry.date ? `**v${entry.version}** — ${entry.date}` : `**v${entry.version}**`;
+      let chunk = header;
+      for (const line of entry.lines) {
+        const candidate = `${chunk}\n${line}`;
+        if (candidate.length > budget && chunk !== header) {
+          pages.push(chunk);
+          chunk = `${header}\n${line}`;
+        } else {
+          chunk = candidate;
+        }
+      }
+      if (chunk.length > 0) pages.push(chunk);
+      continue;
+    }
+
+    const candidate = current.length === 0 ? rendered : `${current}\n\n${rendered}`;
+    if (candidate.length > budget && current.length > 0) {
+      flush();
+      current = rendered;
+    } else {
+      current = candidate;
+    }
+  }
+  flush();
+
+  return pages;
+}
+
+/** The bullet block for one version, for release notes. */
+export function sectionFor(markdown: string, version: string): string | null {
+  const entry = parseChangelog(markdown).find((e) => e.version === version);
+  if (!entry) return null;
+  return entry.lines.join('\n');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { whoKnowsCommands } from './commands/whoknows.js';
 import { rymCommands } from './commands/rym.js';
 import { bannerCommands } from './commands/banner.js';
 import { adminCommands } from './commands/admin.js';
+import { changelogCommands } from './commands/changelog.js';
 import { BannerScheduler } from './banner/worker.js';
 
 async function main(): Promise<void> {
@@ -33,6 +34,7 @@ async function main(): Promise<void> {
     ...rymCommands,
     ...bannerCommands,
     ...adminCommands,
+    ...changelogCommands,
   );
 
   const bot = createBot(config, db, registry);

--- a/test/commands/changelog.test.ts
+++ b/test/commands/changelog.test.ts
@@ -22,11 +22,8 @@ vi.mock('node:fs', async (importOriginal) => {
 
 const changelog = changelogCommands.find((c) => c.name === 'changelog')!;
 
-// Must run before any test below causes a successful default-path read: a
-// success caches the content module-wide, and the cache short-circuits any
-// later read attempt regardless of path.
 describe('read failures', () => {
-  it('readChangelogFile returns null for a nonexistent path, and does not cache it', () => {
+  it('readChangelogFile returns null for a nonexistent path', () => {
     expect(readChangelogFile('/nonexistent/CHANGELOG.md')).toBeNull();
   });
 
@@ -52,13 +49,12 @@ describe('&changelog', () => {
     expect(first.data.description).toContain(readPackageVersion());
     expect(first.data.footer?.text).toMatch(/^page no\. 1\//);
 
-    if (fake.payloads.length > 0) {
-      await fake.click('next');
-      const second = fake.embeds.find((e) =>
-        (e as EmbedBuilder).data.footer?.text?.startsWith('page no. 2/'),
-      );
-      expect(second).toBeDefined();
-    }
+    expect(fake.payloads.length).toBeGreaterThan(0);
+    await fake.click('next');
+    const second = fake.embeds.find((e) =>
+      (e as EmbedBuilder).data.footer?.text?.startsWith('page no. 2/'),
+    );
+    expect(second).toBeDefined();
   });
 
   it('parses the newest entry to match package.json version (catches a forgotten bump entry)', () => {

--- a/test/commands/changelog.test.ts
+++ b/test/commands/changelog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EmbedBuilder } from 'discord.js';
+import { changelogCommands, readChangelogFile } from '../../src/commands/changelog.js';
+import { parseChangelog } from '../../src/commands/changelogFormat.js';
+import { readPackageVersion } from '../../src/core/version.js';
+import { makeFakeMessage } from '../helpers/fake.js';
+
+// Controls whether the mocked `readFileSync` below throws, so the command's
+// read-failure branch is reachable through its real (path-less) call site.
+let failReads = false;
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => {
+      if (failReads) throw new Error('enoent');
+      return actual.readFileSync(...args);
+    },
+  };
+});
+
+const changelog = changelogCommands.find((c) => c.name === 'changelog')!;
+
+// Must run before any test below causes a successful default-path read: a
+// success caches the content module-wide, and the cache short-circuits any
+// later read attempt regardless of path.
+describe('read failures', () => {
+  it('readChangelogFile returns null for a nonexistent path, and does not cache it', () => {
+    expect(readChangelogFile('/nonexistent/CHANGELOG.md')).toBeNull();
+  });
+
+  it('&changelog replies with a not-found message when the file cannot be read', async () => {
+    failReads = true;
+    try {
+      const fake = makeFakeMessage({ content: '&changelog' });
+      await changelog.run({ app: undefined as never, message: fake.message, args: [] });
+      expect(fake.replies[0]).toBe(`couldn't read the changelog.`);
+    } finally {
+      failReads = false;
+    }
+  });
+});
+
+describe('&changelog', () => {
+  it('pages the real repo CHANGELOG.md, with the newest entry matching the running version', async () => {
+    const fake = makeFakeMessage({ content: '&changelog' });
+    await changelog.run({ app: undefined as never, message: fake.message, args: [] });
+
+    expect(fake.embeds.length).toBeGreaterThan(0);
+    const first = fake.embeds[0] as EmbedBuilder;
+    expect(first.data.description).toContain(readPackageVersion());
+    expect(first.data.footer?.text).toMatch(/^page no\. 1\//);
+
+    if (fake.payloads.length > 0) {
+      await fake.click('next');
+      const second = fake.embeds.find((e) =>
+        (e as EmbedBuilder).data.footer?.text?.startsWith('page no. 2/'),
+      );
+      expect(second).toBeDefined();
+    }
+  });
+
+  it('parses the newest entry to match package.json version (catches a forgotten bump entry)', () => {
+    const markdown = readChangelogFile();
+    expect(markdown).not.toBeNull();
+    const entries = parseChangelog(markdown!);
+    expect(entries[0]?.version).toBe(readPackageVersion());
+  });
+});

--- a/test/commands/changelogFormat.test.ts
+++ b/test/commands/changelogFormat.test.ts
@@ -44,6 +44,18 @@ describe('parseChangelog', () => {
   it('returns an empty array for an empty file', () => {
     expect(parseChangelog('')).toEqual([]);
   });
+
+  it('joins a bullet wrapped across two source lines into one entry line', () => {
+    const md = '## [1.2.3] - 2026-01-01\n\n- did a thing that\n  wraps onto the next line\n- did another thing\n';
+    const entries = parseChangelog(md);
+    expect(entries).toEqual([
+      {
+        version: '1.2.3',
+        date: '2026-01-01',
+        lines: ['- did a thing that wraps onto the next line', '- did another thing'],
+      },
+    ]);
+  });
 });
 
 describe('changelogPages', () => {

--- a/test/commands/changelogFormat.test.ts
+++ b/test/commands/changelogFormat.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { changelogPages, parseChangelog, sectionFor } from '../../src/commands/changelogFormat.js';
+
+describe('parseChangelog', () => {
+  it('parses a well-formed heading with bracket and date', () => {
+    const md = '## [1.2.3] - 2026-01-01\n\n- did a thing\n- did another thing\n';
+    const entries = parseChangelog(md);
+    expect(entries).toEqual([
+      { version: '1.2.3', date: '2026-01-01', lines: ['- did a thing', '- did another thing'] },
+    ]);
+  });
+
+  it('parses a bracketless heading', () => {
+    const md = '## 1.2.3 - 2026-01-01\n\n- did a thing\n';
+    expect(parseChangelog(md)).toEqual([
+      { version: '1.2.3', date: '2026-01-01', lines: ['- did a thing'] },
+    ]);
+  });
+
+  it('accepts an em-dash before the date', () => {
+    const md = '## [1.2.3] — 2026-01-01\n\n- did a thing\n';
+    expect(parseChangelog(md)[0]?.date).toBe('2026-01-01');
+  });
+
+  it('tolerates a missing date', () => {
+    const md = '## [1.2.3]\n\n- did a thing\n';
+    expect(parseChangelog(md)).toEqual([{ version: '1.2.3', date: null, lines: ['- did a thing'] }]);
+  });
+
+  it('ignores preamble before the first heading', () => {
+    const md = '# Changelog\n\nSome preamble text.\n\n## [1.0.0] - 2026-01-01\n\n- thing\n';
+    const entries = parseChangelog(md);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.0');
+  });
+
+  it('ignores a non-version heading', () => {
+    const md = '## Changelog\n\n- ignored\n\n## [1.0.0] - 2026-01-01\n\n- thing\n';
+    const entries = parseChangelog(md);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.0');
+  });
+
+  it('returns an empty array for an empty file', () => {
+    expect(parseChangelog('')).toEqual([]);
+  });
+});
+
+describe('changelogPages', () => {
+  it('packs multiple entries onto one page under budget', () => {
+    const entries = parseChangelog(
+      '## [1.0.1] - 2026-01-02\n\n- fix\n\n## [1.0.0] - 2026-01-01\n\n- initial\n',
+    );
+    const pages = changelogPages(entries, 1800);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toContain('v1.0.1');
+    expect(pages[0]).toContain('v1.0.0');
+  });
+
+  it('starts a new page when the next whole entry would exceed the budget', () => {
+    const entries = parseChangelog(
+      '## [1.0.1] - 2026-01-02\n\n- fix\n\n## [1.0.0] - 2026-01-01\n\n- initial\n',
+    );
+    const pages = changelogPages(entries, 30);
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toContain('v1.0.1');
+    expect(pages[1]).toContain('v1.0.0');
+  });
+
+  it('splits an over-budget single entry at line boundaries, repeating the heading', () => {
+    const md =
+      '## [1.0.0] - 2026-01-01\n\n' +
+      Array.from({ length: 10 }, (_, i) => `- line number ${i} is reasonably long text`).join(
+        '\n',
+      ) +
+      '\n';
+    const entries = parseChangelog(md);
+    const pages = changelogPages(entries, 80);
+    expect(pages.length).toBeGreaterThan(1);
+    for (const page of pages) {
+      expect(page).toContain('v1.0.0');
+      expect(page.length).toBeLessThanOrEqual(80 + 60); // heading repeat plus one line's slack
+    }
+  });
+});
+
+describe('sectionFor', () => {
+  const md = '## [1.0.1] - 2026-01-02\n\n- fix\n\n## [1.0.0] - 2026-01-01\n\n- initial\n';
+
+  it('returns the bullet block for a known version', () => {
+    expect(sectionFor(md, '1.0.0')).toBe('- initial');
+  });
+
+  it('returns null for a version not present', () => {
+    expect(sectionFor(md, '9.9.9')).toBeNull();
+  });
+});

--- a/test/scripts/changelogSection.test.ts
+++ b/test/scripts/changelogSection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { sectionFor } from '../../scripts/changelogSection.js';
+
+describe('changelogSection', () => {
+  it('round-trips through sectionFor against the real repo CHANGELOG.md', () => {
+    const markdown = readFileSync('CHANGELOG.md', 'utf8');
+    const entries = markdown.match(/^## \[(\d+\.\d+\.\d+)\]/gm) ?? [];
+    expect(entries.length).toBeGreaterThan(0);
+    const firstVersion = /\[(\d+\.\d+\.\d+)\]/.exec(entries[0]!)![1]!;
+    const section = sectionFor(markdown, firstVersion);
+    expect(section).not.toBeNull();
+    expect(section!.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for a version with no entry', () => {
+    const markdown = readFileSync('CHANGELOG.md', 'utf8');
+    expect(sectionFor(markdown, '0.0.1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a hand-written `CHANGELOG.md` at the repo root, seeded newest-first from the existing 15
release tags (`v2.0.0`–`v2.6.3`), and a `-changelog` command (alias `-changes`) that pages through it
in Discord on the standard ⬅ ➡ button pager. Pages pack *whole* version entries up to a character
budget rather than a fixed line count, so a release never splits across a page boundary; parsing and
packing live in a pure `changelogFormat.ts` sibling module, tested without Discord or a filesystem.

The changelog is also made load-bearing rather than gated: the deploy's release step now prefers the
matching `CHANGELOG.md` section as the GitHub release body, falling back to `--generate-notes` with a
CI warning when a version has no entry. `CHANGELOG.md` is staged into the deploy behind an `[ -f ]`
guard — joining it to the unconditional `cp` would abort the staging step on a rollback to any tag
cut before this change, since the default `run:` shell is `bash -e` and no existing tag carries the
file.

`VERSIONING.md` now documents the entry as part of the version-bump commit (including what a
docs/CI-only release writes), with matching notes in `README.md` and `CLAUDE.md`.

## Why

Every merge already cuts a release, but the notes were auto-generated from commit subjects and
invisible from inside Discord — there was no way to answer "what changed?" without leaving the
server. Writing the entry in the same commit as the version bump keeps the two from drifting, and
consuming it as the release body means the file is used, not aspirational.

## Notes

Planned and adversarially reviewed before implementation; the plan and its review notes are at
`.claude/plans/changelog-command.md`. Version bumped to 2.7.0 (minor — a self-contained new
user-visible command).