### PR TITLE
feat(admin): add -invite and -github commands and link the repo from meta embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ matching section.
 Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
 people using the bot rather than for the diff.
 
+## [2.8.0] - 2026-08-20
+
+- `-invite` (alias `-inv`) gives you a link to add feed1 to another server.
+- `-github` (aliases `-repo`, `-source`) links the bot's source code.
+- The `-changelog` and `-botinfo` titles now link out to GitHub.
+
 ## [2.7.0] - 2026-08-20
 
 - `-changelog` (alias `-changes`) pages through this file in Discord, newest release first.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,8 +1,14 @@
-import { AttachmentBuilder, EmbedBuilder, PermissionFlagsBits } from 'discord.js';
+import {
+  AttachmentBuilder,
+  EmbedBuilder,
+  PermissionFlagsBits,
+  PermissionsBitField,
+} from 'discord.js';
 import type { Command } from '../core/command.js';
 import { disableCommand, enableCommand } from '../core/disables.js';
 import { sendable } from '../core/channel.js';
 import { readPackageVersion } from '../core/version.js';
+import { REPO_URL } from '../core/links.js';
 import { parseLogsArgs, readLogs } from '../ops/logs.js';
 
 const PROTECTED = new Set(['enable', 'disable', 'help']);
@@ -110,6 +116,7 @@ const botinfo: Command = {
     const client = message.client;
     const embed = new EmbedBuilder()
       .setTitle('feed1')
+      .setURL(REPO_URL)
       .setDescription('a Last.fm Discord bot')
       .addFields(
         { name: 'version', value: readPackageVersion(), inline: true },
@@ -117,6 +124,53 @@ const botinfo: Command = {
         { name: 'uptime', value: `${Math.floor(process.uptime() / 60)} min`, inline: true },
         { name: 'commands', value: String(app.registry.all().length), inline: true },
       );
+    return sendable(message).send({ embeds: [embed] });
+  },
+};
+
+const invite: Command = {
+  name: 'invite',
+  aliases: ['inv'],
+  description: 'Gives you a link to add feed1 to another server.',
+  usage: 'invite',
+  guildOnly: false,
+  async run({ message }) {
+    const botId = message.client.user?.id;
+    if (!botId) return message.reply(`still starting up — try again in a second.`);
+
+    const permissions = new PermissionsBitField([
+      PermissionFlagsBits.ViewChannel,
+      PermissionFlagsBits.SendMessages,
+      PermissionFlagsBits.EmbedLinks,
+      PermissionFlagsBits.AttachFiles,
+      PermissionFlagsBits.ReadMessageHistory,
+      PermissionFlagsBits.AddReactions,
+      PermissionFlagsBits.ManageGuild,
+    ]).bitfield.toString();
+    const inviteUrl = `https://discord.com/oauth2/authorize?client_id=${botId}&permissions=${permissions}&scope=bot`;
+
+    const embed = new EmbedBuilder()
+      .setTitle('add feed1 to your server')
+      .setURL(inviteUrl)
+      .setDescription(
+        `[click here](${inviteUrl}) to add feed1 to another server. Manage Server is only used ` +
+          `by \`-banner\` for banner rotation.`,
+      );
+    return sendable(message).send({ embeds: [embed] });
+  },
+};
+
+const github: Command = {
+  name: 'github',
+  aliases: ['repo', 'source'],
+  description: `Links the bot's source code on GitHub.`,
+  usage: 'github',
+  guildOnly: false,
+  async run({ message }) {
+    const embed = new EmbedBuilder()
+      .setTitle('feed1 on GitHub')
+      .setURL(REPO_URL)
+      .setDescription(REPO_URL);
     return sendable(message).send({ embeds: [embed] });
   },
 };
@@ -177,6 +231,8 @@ export const adminCommands: Command[] = [
   help,
   ping,
   botinfo,
+  invite,
+  github,
   restart,
   logs,
 ];

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -4,6 +4,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { Command } from '../core/command.js';
 import { sendPaginatedEmbed } from '../core/paginate.js';
 import { readPackageVersion } from '../core/version.js';
+import { RELEASES_URL } from '../core/links.js';
 import { changelogPages, parseChangelog } from './changelogFormat.js';
 
 const DEFAULT_PATH = fileURLToPath(new URL('../../CHANGELOG.md', import.meta.url));
@@ -32,6 +33,7 @@ const changelog: Command = {
     const embeds = pages.map((description, i) =>
       new EmbedBuilder()
         .setTitle('feed1 changelog')
+        .setURL(RELEASES_URL)
         .setColor(message.member?.displayColor ?? null)
         .setDescription(description)
         .setFooter({

--- a/src/core/links.ts
+++ b/src/core/links.ts
@@ -1,0 +1,2 @@
+export const REPO_URL = 'https://github.com/mxttbennett/feed1';
+export const RELEASES_URL = `${REPO_URL}/releases`;

--- a/test/commands/admin.test.ts
+++ b/test/commands/admin.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { PermissionsBitField } from 'discord.js';
 import type { EmbedBuilder } from 'discord.js';
 import { adminCommands } from '../../src/commands/admin.js';
 import { fm } from '../../src/commands/fm.js';
 import { Router } from '../../src/core/router.js';
 import { readPackageVersion } from '../../src/core/version.js';
+import { REPO_URL } from '../../src/core/links.js';
 import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
 
 const byName = (name: string) => adminCommands.find((c) => c.name === name)!;
@@ -57,6 +59,8 @@ describe('&help', () => {
     const embed = fake.embeds[0] as EmbedBuilder;
     expect(embed.data.description).toContain('`fm`');
     expect(embed.data.description).toContain('`help`');
+    expect(embed.data.description).toContain('`invite`');
+    expect(embed.data.description).toContain('`github`');
     expect(embed.data.description).not.toContain('`r`');
   });
 
@@ -80,5 +84,44 @@ describe('&botinfo', () => {
     const version = embed.data.fields?.find((f) => f.name === 'version');
     expect(version?.value).toBe(readPackageVersion());
     expect(version?.value).not.toBe('unknown');
+  });
+});
+
+describe('&invite', () => {
+  it('builds an oauth2 invite url with the expected permissions', async () => {
+    const app = appWithAll();
+    const fake = makeFakeMessage({ content: '&invite' });
+    await byName('invite').run({ app, message: fake.message, args: [] });
+
+    const embed = fake.embeds[0] as EmbedBuilder;
+    const url = new URL(embed.data.url!);
+    expect(url.searchParams.get('client_id')).toBe('bot-1');
+    expect(url.searchParams.get('scope')).toBe('bot');
+
+    const permissions = new PermissionsBitField(
+      BigInt(url.searchParams.get('permissions')!),
+    );
+    expect(permissions.has('ManageGuild')).toBe(true);
+    expect(permissions.has('AddReactions')).toBe(true);
+  });
+
+  it('replies with a still-starting-up message when client.user is absent', async () => {
+    const app = appWithAll();
+    const fake = makeFakeMessage({ content: '&invite' });
+    (fake.message.client as { user: unknown }).user = null;
+    await byName('invite').run({ app, message: fake.message, args: [] });
+    expect(fake.replies[0]).toBe('still starting up — try again in a second.');
+  });
+});
+
+describe('&github', () => {
+  it('links the repo in both the url and description', async () => {
+    const app = appWithAll();
+    const fake = makeFakeMessage({ content: '&github' });
+    await byName('github').run({ app, message: fake.message, args: [] });
+
+    const embed = fake.embeds[0] as EmbedBuilder;
+    expect(embed.data.url).toBe(REPO_URL);
+    expect(embed.data.description).toContain(REPO_URL);
   });
 });

--- a/test/commands/changelog.test.ts
+++ b/test/commands/changelog.test.ts
@@ -3,6 +3,7 @@ import type { EmbedBuilder } from 'discord.js';
 import { changelogCommands, readChangelogFile } from '../../src/commands/changelog.js';
 import { parseChangelog } from '../../src/commands/changelogFormat.js';
 import { readPackageVersion } from '../../src/core/version.js';
+import { RELEASES_URL } from '../../src/core/links.js';
 import { makeFakeMessage } from '../helpers/fake.js';
 
 // Controls whether the mocked `readFileSync` below throws, so the command's
@@ -48,6 +49,7 @@ describe('&changelog', () => {
     const first = fake.embeds[0] as EmbedBuilder;
     expect(first.data.description).toContain(readPackageVersion());
     expect(first.data.footer?.text).toMatch(/^page no\. 1\//);
+    expect(first.data.url).toBe(RELEASES_URL);
 
     expect(fake.payloads.length).toBeGreaterThan(0);
     await fake.click('next');

--- a/test/helpers/fake.ts
+++ b/test/helpers/fake.ts
@@ -86,6 +86,7 @@ export interface FakeMessageOptions {
   attachmentUrls?: string[];
   /** the message this one replies to, for `-banner add` in reply to an image */
   repliedTo?: { attachmentUrls?: string[]; content?: string };
+  botId?: string;
 }
 
 export interface FakeMessage {
@@ -198,6 +199,7 @@ export function makeFakeMessage(opts: FakeMessageOptions): FakeMessage {
     client: {
       guilds: { cache: { size: 1 } },
       users: { fetch: opts.fetchUser ?? (() => Promise.resolve(null)) },
+      user: { id: opts.botId ?? 'bot-1' },
     },
     mentions: {
       users: {

--- a/test/live/smoke.ts
+++ b/test/live/smoke.ts
@@ -55,10 +55,25 @@ const CASES: SmokeCase[] = [
     describe: 'mylogin answers',
   },
   {
-    name: 'unknown command silence is not asserted',
+    name: 'botinfo',
     send: `${PREFIX}botinfo`,
     expect: (m) => m.embeds[0]?.title === 'feed1',
     describe: 'botinfo embed',
+  },
+  {
+    name: 'invite',
+    send: `${PREFIX}invite`,
+    expect: (m) => {
+      const url = m.embeds[0]?.url ?? '';
+      return url.includes('client_id=') && url.includes('scope=bot');
+    },
+    describe: 'invite embed carries a real oauth2 url',
+  },
+  {
+    name: 'github',
+    send: `${PREFIX}github`,
+    expect: (m) => m.embeds[0]?.title === 'feed1 on GitHub',
+    describe: 'github embed',
   },
 ];
 


### PR DESCRIPTION
## What

Adds two small meta commands and makes the existing ones link out.

- **`-invite`** (alias `-inv`) replies with an OAuth2 link to add feed1 to another server. The
  client id comes from the running client's own application id (`message.client.user.id`), so no
  client id has to be configured and the dev bot and prod bot each emit their own correct link.
  Permissions are computed from named `PermissionFlagsBits` rather than a literal integer, so the
  grant stays auditable: `ViewChannel`, `SendMessages`, `EmbedLinks`, `AttachFiles`,
  `ReadMessageHistory`, `AddReactions`, `ManageGuild`. Each one is there because the bot actually
  calls the API behind it — `AddReactions` for the chart progress reactions in `charts.ts`,
  `ManageGuild` for `guild.setBanner()` in the banner rotation. The embed says out loud that
  Manage Server is only used by `-banner`, since that permission is alarming without a reason.
- **`-github`** (aliases `-repo`, `-source`) links the source.
- The **`-changelog`** and **`-botinfo`** embed titles now carry URLs (releases page and repo root),
  so the repo is reachable without knowing a second command exists. No new embed copy — the titles
  were already there, they just weren't links.

Both commands live in `admin.ts` next to `help`/`ping`/`botinfo` and are added to the existing
`adminCommands` array, so `src/index.ts` is untouched and `-help` picks them up automatically from
the registry. They are deliberately *not* added to `PROTECTED` — that set exists only so a bad
`-disable` stays recoverable, which these two aren't.

Drive-by: the `botinfo` case in `test/live/smoke.ts` had a copy-paste `name` reading
`'unknown command silence is not asserted'` while its body sends `-botinfo`. Fixed while adding the
two adjacent cases.

## Why

Both were asked for directly: a way for people to add the bot to their own servers, and a way to
reach the source from inside Discord. The GitHub link is done as *both* a command and hyperlinked
titles on purpose — a link living only inside `-changelog` would be undiscoverable, since nobody
opens release notes looking for source code, while `setURL()` on titles that already exist costs
nothing visually.

No Linear ticket.

## Notes

- **Check the Discord developer portal before announcing `-invite`.** If the application is set to
  private (Application → Bot → "Public Bot" off), the link only works for the owner. Nothing in the
  code can detect or fix that.
- The unit test for `-invite` asserts against a stubbed bot id, so it can't validate a real invite
  URL — that's why a live case was added to `test/live/smoke.ts` (not run by CI; needs `npm run smoke`
  against a dev bot).

## Verification

`npm run typecheck`, `npm run lint`, `npm test` all clean — 317 tests across 25 files, up from a
314-test baseline.
