### PR TITLE
feat(embeds): use the full-resolution Last.fm image in embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ matching section.
 Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
 people using the bot rather than for the diff.
 
+## [2.10.0] - 2026-08-27
+
+- Album and artist art in `-fm`, `-wk` and `-wka` embeds is now the full-resolution original
+  instead of a 174px thumbnail, so clicking through gives you the real cover.
+
 ## [2.9.0] - 2026-08-27
 
 - The album version of who-knows is now `-wka`. `-a` still works as an alias.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/fm.ts
+++ b/src/commands/fm.ts
@@ -10,7 +10,7 @@ import { gatherRegisteredMembers } from '../crowns/members.js';
 import { notifyCrownChange } from '../crowns/notify.js';
 import { CrownService } from '../crowns/service.js';
 import { enqueueCrownJob } from '../crowns/worker.js';
-import { imageUrl, toInt } from '../lastfm/types.js';
+import { bestImageUrl, toInt } from '../lastfm/types.js';
 import type { Period, RecentTrack } from '../lastfm/types.js';
 import {
   CROWN_GIF_DEFAULT,
@@ -135,7 +135,7 @@ function baseEmbed(message: Message, lastfmUser: string, track: RecentTrack): Em
     })
     .setTitle(`**${escapeAsterisks(track.name)}**`)
     .setDescription(fmDescription(artist, album))
-    .setThumbnail(imageUrl(track.image, 2) || null);
+    .setThumbnail(bestImageUrl(track.image) || null);
 }
 
 export const fm: Command = {

--- a/src/commands/fm.ts
+++ b/src/commands/fm.ts
@@ -10,7 +10,7 @@ import { gatherRegisteredMembers } from '../crowns/members.js';
 import { notifyCrownChange } from '../crowns/notify.js';
 import { CrownService } from '../crowns/service.js';
 import { enqueueCrownJob } from '../crowns/worker.js';
-import { bestImageUrl, toInt } from '../lastfm/types.js';
+import { highestResImageUrl, toInt } from '../lastfm/types.js';
 import type { Period, RecentTrack } from '../lastfm/types.js';
 import {
   CROWN_GIF_DEFAULT,
@@ -135,7 +135,7 @@ function baseEmbed(message: Message, lastfmUser: string, track: RecentTrack): Em
     })
     .setTitle(`**${escapeAsterisks(track.name)}**`)
     .setDescription(fmDescription(artist, album))
-    .setThumbnail(bestImageUrl(track.image) || null);
+    .setThumbnail(highestResImageUrl(track.image) || null);
 }
 
 export const fm: Command = {
@@ -207,13 +207,8 @@ export const fm: Command = {
           crownArtist = albumData.album.artist;
           crownAlbum = albumData.album.name;
           crownGif =
-            albumCrownGif(
-              app.db,
-              message.guild!.id,
-              crownArtist,
-              crownAlbum,
-              message.author.id,
-            ) ?? CROWN_GIF_DEFAULT;
+            albumCrownGif(app.db, message.guild!.id, crownArtist, crownAlbum, message.author.id) ??
+            CROWN_GIF_DEFAULT;
         } catch {
           // no album info → no album segment, default gif
         }

--- a/src/crowns/service.ts
+++ b/src/crowns/service.ts
@@ -3,7 +3,7 @@ import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
 import type { LastfmClient } from '../lastfm/client.js';
 import { LastfmError } from '../lastfm/errors.js';
-import { toInt } from '../lastfm/types.js';
+import { bestImageUrl, toInt } from '../lastfm/types.js';
 import type { KeyedMutex } from '../core/mutex.js';
 
 export type CrownKind = 'artist' | 'album';
@@ -92,13 +92,13 @@ export class CrownService {
           canonicalAlbum = info.album.name;
           canonicalArtist = info.album.artist;
           albumUrl = info.album.url;
-          image = info.album.image?.[2]?.['#text'] ?? image;
+          image = bestImageUrl(info.album.image) || image;
         } else {
           const info = await this.lastfm.getArtistInfo(target.artistName, member.lastfmUsername);
           plays = toInt(info.artist.stats.userplaycount);
           canonicalArtist = info.artist.name;
           artistUrl = info.artist.url;
-          image = info.artist.image?.[2]?.['#text'] ?? image;
+          image = bestImageUrl(info.artist.image) || image;
         }
         listeners.push({ ...member, plays });
       } catch (error) {

--- a/src/crowns/service.ts
+++ b/src/crowns/service.ts
@@ -3,7 +3,7 @@ import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
 import type { LastfmClient } from '../lastfm/client.js';
 import { LastfmError } from '../lastfm/errors.js';
-import { bestImageUrl, toInt } from '../lastfm/types.js';
+import { highestResImageUrl, toInt } from '../lastfm/types.js';
 import type { KeyedMutex } from '../core/mutex.js';
 
 export type CrownKind = 'artist' | 'album';
@@ -92,13 +92,13 @@ export class CrownService {
           canonicalAlbum = info.album.name;
           canonicalArtist = info.album.artist;
           albumUrl = info.album.url;
-          image = bestImageUrl(info.album.image) || image;
+          image = highestResImageUrl(info.album.image) || image;
         } else {
           const info = await this.lastfm.getArtistInfo(target.artistName, member.lastfmUsername);
           plays = toInt(info.artist.stats.userplaycount);
           canonicalArtist = info.artist.name;
           artistUrl = info.artist.url;
-          image = bestImageUrl(info.artist.image) || image;
+          image = highestResImageUrl(info.artist.image) || image;
         }
         listeners.push({ ...member, plays });
       } catch (error) {
@@ -135,10 +135,7 @@ export class CrownService {
     if (change) await this.onChange(change);
 
     const tookMs = this.now() - started;
-    this.db
-      .insert(schema.scanTimings)
-      .values({ kind, guildId: target.guildId, ms: tookMs })
-      .run();
+    this.db.insert(schema.scanTimings).values({ kind, guildId: target.guildId, ms: tookMs }).run();
 
     return {
       listeners,
@@ -189,9 +186,7 @@ export class CrownService {
             )
             .get();
 
-    const incumbent = existing
-      ? listeners.find((l) => l.userId === existing.userId)
-      : undefined;
+    const incumbent = existing ? listeners.find((l) => l.userId === existing.userId) : undefined;
 
     const prevOwnerId = existing?.userId ?? null;
     const prevPlays = existing

--- a/src/lastfm/types.ts
+++ b/src/lastfm/types.ts
@@ -116,7 +116,7 @@ export function originalSize(url: string): string {
 export function highestResImageUrl(images: LastfmImage[] | undefined): string {
   if (!images?.length) return '';
   const named = new Map(images.filter((i) => i['#text']).map((i) => [i.size, i['#text']]));
-  const best =
+  const highest =
     SIZE_PREFERENCE.map((size) => named.get(size)).find(Boolean) ?? [...named.values()][0];
-  return best ? originalSize(best) : '';
+  return highest ? originalSize(highest) : '';
 }

--- a/src/lastfm/types.ts
+++ b/src/lastfm/types.ts
@@ -113,7 +113,7 @@ export function originalSize(url: string): string {
 }
 
 /** Highest-resolution URL available for an image set, or '' when there is none. */
-export function bestImageUrl(images: LastfmImage[] | undefined): string {
+export function highestResImageUrl(images: LastfmImage[] | undefined): string {
   if (!images?.length) return '';
   const named = new Map(images.filter((i) => i['#text']).map((i) => [i.size, i['#text']]));
   const best =

--- a/src/lastfm/types.ts
+++ b/src/lastfm/types.ts
@@ -100,3 +100,23 @@ export function toInt(value: string | number | undefined): number {
 export function imageUrl(images: LastfmImage[] | undefined, sizeIndex: number): string {
   return images?.[sizeIndex]?.['#text'] ?? '';
 }
+
+const SIZE_PREFERENCE = ['mega', 'extralarge', 'large', 'medium', 'small'];
+
+/**
+ * Last.fm serves every image off one hash with the dimensions as a path segment
+ * (`/i/u/300x300/<hash>.jpg`); dropping the segment yields the original upload, which is
+ * far larger than the 300x300 that `extralarge` and `mega` both point at.
+ */
+export function originalSize(url: string): string {
+  return url.replace(/^(https:\/\/lastfm\.freetls\.fastly\.net\/i\/u\/)[^/]+\/([^/]+)$/, '$1$2');
+}
+
+/** Highest-resolution URL available for an image set, or '' when there is none. */
+export function bestImageUrl(images: LastfmImage[] | undefined): string {
+  if (!images?.length) return '';
+  const named = new Map(images.filter((i) => i['#text']).map((i) => [i.size, i['#text']]));
+  const best =
+    SIZE_PREFERENCE.map((size) => named.get(size)).find(Boolean) ?? [...named.values()][0];
+  return best ? originalSize(best) : '';
+}

--- a/test/commands/fm.test.ts
+++ b/test/commands/fm.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../src/commands/fmFormat.js';
 
 const BASE = 'https://ws.audioscrobbler.com';
+const CDN = 'https://lastfm.freetls.fastly.net/i/u';
 
 const SCROBBLES = 'scrobbles → all: 5000 | artist: 250 | album: 42';
 const ARTIST_RANKS = '\nartist ranks → w: #1 | m: #1 | y: #1 | o: #1';
@@ -30,10 +31,10 @@ function recentTracksBody(nowPlaying: boolean, album = 'Gantz Graf') {
           artist: { '#text': 'Autechre', mbid: '' },
           album: { '#text': album, mbid: '' },
           image: [
-            { size: 'small', '#text': 'https://img.example/s.png' },
-            { size: 'medium', '#text': 'https://img.example/m.png' },
-            { size: 'large', '#text': 'https://img.example/l.png' },
-            { size: 'extralarge', '#text': 'https://img.example/xl.png' },
+            { size: 'small', '#text': `${CDN}/34s/gantzgraf.png` },
+            { size: 'medium', '#text': `${CDN}/64s/gantzgraf.png` },
+            { size: 'large', '#text': `${CDN}/174s/gantzgraf.png` },
+            { size: 'extralarge', '#text': `${CDN}/300x300/gantzgraf.png` },
           ],
           url: 'https://www.last.fm/music/Autechre/_/Gantz+Graf',
           ...(nowPlaying ? { '@attr': { nowplaying: 'true' } } : {}),
@@ -186,6 +187,7 @@ describe('&fm', () => {
     expect(first.data.footer?.icon_url).toBe(LOADING_GIF);
     expect(first.data.title).toBe('**Gantz Graf**');
     expect(first.data.description).toContain('[***Gantz Graf***](');
+    expect(first.data.thumbnail?.url).toBe(`${CDN}/gantzgraf.png`);
 
     // one edit for the scrobbles footer, then one per resolved rank period
     expect(fake.edits).toHaveLength(9);

--- a/test/commands/whoknows.test.ts
+++ b/test/commands/whoknows.test.ts
@@ -8,6 +8,7 @@ import { makeFakeApp, makeFakeMessage, withGuildMembers } from '../helpers/fake.
 import type { Message } from 'discord.js';
 
 const BASE = 'https://ws.audioscrobbler.com';
+const CDN = 'https://lastfm.freetls.fastly.net/i/u';
 const byName = (name: string) => whoKnowsCommands.find((c) => c.name === name)!;
 
 beforeAll(() => nock.disableNetConnect());
@@ -141,7 +142,8 @@ describe('&a', () => {
           image: [
             { size: 'small', '#text': '' },
             { size: 'medium', '#text': '' },
-            { size: 'large', '#text': 'https://img.example/l.png' },
+            { size: 'large', '#text': `${CDN}/174s/confield.png` },
+            { size: 'extralarge', '#text': `${CDN}/300x300/confield.png` },
           ],
         },
       });
@@ -153,6 +155,7 @@ describe('&a', () => {
     const embed = fake.embeds[0] as EmbedBuilder;
     expect(embed.data.title).toBe('*Confield*');
     expect(embed.data.author?.name).toBe('Autechre');
+    expect(embed.data.thumbnail?.url).toBe(`${CDN}/confield.png`);
     expect(app.db.select().from(schema.albumCrowns).all()[0]!.albumName).toBe('Confield');
   });
 

--- a/test/lastfm/images.test.ts
+++ b/test/lastfm/images.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { bestImageUrl, originalSize } from '../../src/lastfm/types.js';
+import { highestResImageUrl, originalSize } from '../../src/lastfm/types.js';
 import type { LastfmImage } from '../../src/lastfm/types.js';
 
 const CDN = 'https://lastfm.freetls.fastly.net/i/u';
@@ -25,42 +25,44 @@ describe('originalSize', () => {
   });
 });
 
-describe('bestImageUrl', () => {
+describe('highestResImageUrl', () => {
   // a distinct hash per size, so the pick is observable after the dimensions are stripped
   const sized = (...sizes: string[]): LastfmImage[] =>
     sizes.map((size) => ({ size, '#text': `${CDN}/300x300/${size}.jpg` }));
 
   it('prefers the largest named size', () => {
-    expect(bestImageUrl(sized('small', 'large', 'mega'))).toBe(`${CDN}/mega.jpg`);
-    expect(bestImageUrl(sized('small', 'large', 'extralarge'))).toBe(`${CDN}/extralarge.jpg`);
+    expect(highestResImageUrl(sized('small', 'large', 'mega'))).toBe(`${CDN}/mega.jpg`);
+    expect(highestResImageUrl(sized('small', 'large', 'extralarge'))).toBe(`${CDN}/extralarge.jpg`);
   });
 
   it('falls back down the size ladder', () => {
-    expect(bestImageUrl(sized('small', 'medium'))).toBe(`${CDN}/medium.jpg`);
+    expect(highestResImageUrl(sized('small', 'medium'))).toBe(`${CDN}/medium.jpg`);
   });
 
   it('takes the first usable entry when no size is recognised', () => {
-    expect(bestImageUrl([{ size: 'huge', '#text': `${CDN}/1000x1000/${HASH}` }])).toBe(
+    expect(highestResImageUrl([{ size: 'huge', '#text': `${CDN}/1000x1000/${HASH}` }])).toBe(
       `${CDN}/${HASH}`,
     );
   });
 
   it('skips entries with a blank URL', () => {
-    expect(bestImageUrl([{ size: 'mega', '#text': '' }, ...sized('large')])).toBe(
+    expect(highestResImageUrl([{ size: 'mega', '#text': '' }, ...sized('large')])).toBe(
       `${CDN}/large.jpg`,
     );
   });
 
   it('returns empty for a missing or empty image set', () => {
-    expect(bestImageUrl(undefined)).toBe('');
-    expect(bestImageUrl([])).toBe('');
-    expect(bestImageUrl([{ size: 'mega', '#text': '' }])).toBe('');
+    expect(highestResImageUrl(undefined)).toBe('');
+    expect(highestResImageUrl([])).toBe('');
+    expect(highestResImageUrl([{ size: 'mega', '#text': '' }])).toBe('');
   });
 
   it('unsizes the real album.getinfo and artist.getinfo payloads', () => {
     const album = fixture('album_getinfo') as unknown as { album: { image: LastfmImage[] } };
     const artist = fixture('artist_getinfo') as unknown as { artist: { image: LastfmImage[] } };
-    expect(bestImageUrl(album.album.image)).toBe(`${CDN}/${HASH}`);
-    expect(bestImageUrl(artist.artist.image)).toBe(`${CDN}/10ede3abec1bb37ad564a80bed01563d.png`);
+    expect(highestResImageUrl(album.album.image)).toBe(`${CDN}/${HASH}`);
+    expect(highestResImageUrl(artist.artist.image)).toBe(
+      `${CDN}/10ede3abec1bb37ad564a80bed01563d.png`,
+    );
   });
 });

--- a/test/lastfm/images.test.ts
+++ b/test/lastfm/images.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { bestImageUrl, originalSize } from '../../src/lastfm/types.js';
+import type { LastfmImage } from '../../src/lastfm/types.js';
+
+const CDN = 'https://lastfm.freetls.fastly.net/i/u';
+const HASH = '02f3dda4fe9195bc5d31c638afbd0471.jpg';
+
+const fixture = (name: string) =>
+  JSON.parse(readFileSync(`test/lastfm/fixtures/${name}.json`, 'utf8')) as Record<string, never>;
+
+describe('originalSize', () => {
+  it('drops the dimensions segment', () => {
+    expect(originalSize(`${CDN}/300x300/${HASH}`)).toBe(`${CDN}/${HASH}`);
+    expect(originalSize(`${CDN}/174s/${HASH}`)).toBe(`${CDN}/${HASH}`);
+  });
+
+  it('leaves a URL that is already unsized alone', () => {
+    expect(originalSize(`${CDN}/${HASH}`)).toBe(`${CDN}/${HASH}`);
+  });
+
+  it('leaves URLs from anywhere else untouched', () => {
+    const foreign = 'https://example.com/i/u/300x300/cover.jpg';
+    expect(originalSize(foreign)).toBe(foreign);
+  });
+});
+
+describe('bestImageUrl', () => {
+  // a distinct hash per size, so the pick is observable after the dimensions are stripped
+  const sized = (...sizes: string[]): LastfmImage[] =>
+    sizes.map((size) => ({ size, '#text': `${CDN}/300x300/${size}.jpg` }));
+
+  it('prefers the largest named size', () => {
+    expect(bestImageUrl(sized('small', 'large', 'mega'))).toBe(`${CDN}/mega.jpg`);
+    expect(bestImageUrl(sized('small', 'large', 'extralarge'))).toBe(`${CDN}/extralarge.jpg`);
+  });
+
+  it('falls back down the size ladder', () => {
+    expect(bestImageUrl(sized('small', 'medium'))).toBe(`${CDN}/medium.jpg`);
+  });
+
+  it('takes the first usable entry when no size is recognised', () => {
+    expect(bestImageUrl([{ size: 'huge', '#text': `${CDN}/1000x1000/${HASH}` }])).toBe(
+      `${CDN}/${HASH}`,
+    );
+  });
+
+  it('skips entries with a blank URL', () => {
+    expect(bestImageUrl([{ size: 'mega', '#text': '' }, ...sized('large')])).toBe(
+      `${CDN}/large.jpg`,
+    );
+  });
+
+  it('returns empty for a missing or empty image set', () => {
+    expect(bestImageUrl(undefined)).toBe('');
+    expect(bestImageUrl([])).toBe('');
+    expect(bestImageUrl([{ size: 'mega', '#text': '' }])).toBe('');
+  });
+
+  it('unsizes the real album.getinfo and artist.getinfo payloads', () => {
+    const album = fixture('album_getinfo') as unknown as { album: { image: LastfmImage[] } };
+    const artist = fixture('artist_getinfo') as unknown as { artist: { image: LastfmImage[] } };
+    expect(bestImageUrl(album.album.image)).toBe(`${CDN}/${HASH}`);
+    expect(bestImageUrl(artist.artist.image)).toBe(`${CDN}/10ede3abec1bb37ad564a80bed01563d.png`);
+  });
+});


### PR DESCRIPTION
## What

Embeds were pulling `image[2]` — Last.fm's `large`, which is 174×174. They now use `bestImageUrl()`, which picks the largest *named* size present (`mega` → `extralarge` → …) and then strips the dimensions segment from the CDN path, since Last.fm serves every variant off one hash and the unsized URL is the original upload:

| URL | Bytes |
|---|---|
| `/i/u/174s/<hash>.jpg` (before) | ~5 KB |
| `/i/u/300x300/<hash>.jpg` (largest named size) | 14 KB |
| `/i/u/<hash>.jpg` (now) | 323 KB |

The rewrite is anchored to the `lastfm.freetls.fastly.net/i/u/` host and path shape, so anything else — a foreign host, an already-unsized URL — passes through untouched and the worst case is the size we would have picked anyway.

Applies to `-fm` (`src/commands/fm.ts`) and the `-wk`/`-wka` thumbnails, which source their image through `CrownService.scan` (`src/crowns/service.ts`). **Chart tiles deliberately keep 300×300** — a 5×5 grid is 25 downloads and node-canvas renders each tile small, so a bigger source there buys bandwidth and little else.

## Why

174×174 looks soft on hi-dpi displays, and clicking an embed opened a thumbnail rather than the actual cover.