### PR TITLE
feat(rym): add -rymsc server chart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ matching section.
 Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
 people using the bot rather than for the diff.
 
+## [2.11.0] - 2026-08-27
+
+- `-rymsc` (alias `-rsc`) links a RateYourMusic chart built from the combined ratings of everyone
+  in the server who is logged into RYM with the bot.
+- `-rymsc --genre <genre>` (or `-g`) narrows the chart to one genre, and `--exclude-rated` hides
+  releases you have already rated. Soundtracks are deweighted unless you pass `--soundtracks`.
+
 ## [2.10.0] - 2026-08-27
 
 - Album and artist art in `-fm`, `-wk` and `-wka` embeds is now the full-resolution original

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed1",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/rym.ts
+++ b/src/commands/rym.ts
@@ -1,13 +1,15 @@
 import { EmbedBuilder } from 'discord.js';
-import { eq } from 'drizzle-orm';
-import type { Message, User as DiscordUser } from 'discord.js';
+import { eq, inArray } from 'drizzle-orm';
+import type { Guild, Message, User as DiscordUser } from 'discord.js';
 import type { Command, CommandContext } from '../core/command.js';
 import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
 import { getRegisteredUser, resolveTargetUser } from '../core/users.js';
 import type { UserRow } from '../core/users.js';
 import { sendable } from '../core/channel.js';
+import { guildMemberCache } from '../core/members.js';
 import { paginateLines, sendPaginatedEmbed } from '../core/paginate.js';
+import { buildServerChartUrl, parseServerChartArgs } from './rymChart.js';
 
 type RymRow = UserRow & { rymUsername: string };
 
@@ -427,6 +429,45 @@ const srand: Command = {
   },
 };
 
+async function gatherRymUsernames(db: Db, guild: Guild): Promise<string[]> {
+  const members = await guildMemberCache(guild);
+  const ids = [...members.filter((m) => !m.user.bot).keys()];
+  if (ids.length === 0) return [];
+
+  const rows = db
+    .select()
+    .from(schema.users)
+    .where(inArray(schema.users.discordUserId, ids))
+    .all();
+
+  const names = rows.map((row) => row.rymUsername?.trim()).filter((n): n is string => !!n);
+  return [...new Set(names)].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+const rymsc: Command = {
+  name: 'rymsc',
+  aliases: ['rsc'],
+  description: `Builds a RYM chart from the combined ratings of everyone in this server.`,
+  usage: 'rymsc [--genre <genre>] [--exclude-rated] [--soundtracks]',
+  notes:
+    'Only members logged into RYM with the bot are counted. Soundtracks are deweighted ' +
+    'unless you pass --soundtracks.',
+  guildOnly: true,
+  async run({ app, message, args }) {
+    const parsed = parseServerChartArgs(args);
+    if (parsed.error) {
+      return message.reply(`${parsed.error} usage: \`${app.config.prefix}${rymsc.usage}\``);
+    }
+
+    const usernames = await gatherRymUsernames(app.db, message.guild!);
+    if (usernames.length === 0) return message.reply(`no one in this server is logged into rym.`);
+
+    const url = buildServerChartUrl({ ...parsed, usernames });
+    const who = `${usernames.length} ${usernames.length === 1 ? 'user' : 'users'}`;
+    return sendable(message).send(`this server's RYM chart (${who}): ${url}`);
+  },
+};
+
 export const rymCommands: Command[] = [
   rym,
   rstat,
@@ -449,4 +490,5 @@ export const rymCommands: Command[] = [
   wrand,
   trand,
   srand,
+  rymsc,
 ];

--- a/src/commands/rymChart.ts
+++ b/src/commands/rymChart.ts
@@ -1,0 +1,73 @@
+const BASE = 'https://rateyourmusic.com/charts/top/album,ep,comp,mixtape,djmix/all-time/';
+
+/** RYM genre slugs are lowercase and hyphenated, with the hyphen URL-encoded. */
+export function genreSlug(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '%2d')
+    .replace(/^(?:%2d)+|(?:%2d)+$/g, '');
+}
+
+export interface ServerChartOptions {
+  usernames: string[];
+  genre?: string;
+  excludeRated?: boolean;
+  keepSoundtracks?: boolean;
+}
+
+/** Segment order is load-bearing — RYM 404s a chart whose filters are shuffled. */
+export function buildServerChartUrl(opts: ServerChartOptions): string {
+  const segments = [];
+  if (opts.genre) segments.push(`g:${genreSlug(opts.genre)}`);
+  segments.push(`u:${opts.usernames.join(',')}`);
+  if (!opts.keepSoundtracks) segments.push('deweight:soundtrack');
+  if (opts.excludeRated) segments.push('excl:ratings');
+  return BASE + segments.map((s) => `${s}/`).join('');
+}
+
+export interface ServerChartArgs {
+  genre?: string;
+  excludeRated: boolean;
+  keepSoundtracks: boolean;
+  /** set when the input can't be honoured; the caller replies with usage instead */
+  error?: string;
+}
+
+const GENRE_FLAGS = new Set(['-g', '--genre']);
+
+export function parseServerChartArgs(args: string[]): ServerChartArgs {
+  const parsed: ServerChartArgs = { excludeRated: false, keepSoundtracks: false };
+  const genreWords: string[] = [];
+  let collectingGenre = false;
+
+  for (const arg of args) {
+    const flag = arg.toLowerCase();
+    if (GENRE_FLAGS.has(flag)) {
+      if (genreWords.length > 0 || collectingGenre) {
+        return { ...parsed, error: 'you can only give one genre.' };
+      }
+      collectingGenre = true;
+      continue;
+    }
+    if (flag === '--exclude-rated' || flag === '--excl') {
+      collectingGenre = false;
+      parsed.excludeRated = true;
+      continue;
+    }
+    if (flag === '--soundtracks') {
+      collectingGenre = false;
+      parsed.keepSoundtracks = true;
+      continue;
+    }
+    if (arg.startsWith('-')) return { ...parsed, error: `I don't know the \`${arg}\` option.` };
+    if (!collectingGenre) return { ...parsed, error: `I don't know what \`${arg}\` means here.` };
+    genreWords.push(arg);
+  }
+
+  if (collectingGenre && genreWords.length === 0) {
+    return { ...parsed, error: 'that genre flag needs a genre after it.' };
+  }
+  if (genreWords.length > 0) parsed.genre = genreWords.join(' ');
+  return parsed;
+}

--- a/src/core/members.ts
+++ b/src/core/members.ts
@@ -1,0 +1,14 @@
+import type { Collection, Guild, GuildMember } from 'discord.js';
+
+/**
+ * A full members.fetch() hits the gateway REQUEST_GUILD_MEMBERS op, which Discord
+ * rate-limits; doing it on every command trips GatewayRateLimitError on rapid calls.
+ * Fetch only when the cache is missing members — the GuildMembers intent keeps it
+ * current afterwards.
+ */
+export async function guildMemberCache(guild: Guild): Promise<Collection<string, GuildMember>> {
+  if (guild.members.cache.size < guild.memberCount) {
+    await guild.members.fetch().catch(() => undefined);
+  }
+  return guild.members.cache;
+}

--- a/src/crowns/members.ts
+++ b/src/crowns/members.ts
@@ -2,6 +2,7 @@ import { inArray } from 'drizzle-orm';
 import type { Guild } from 'discord.js';
 import type { Db } from '../db/index.js';
 import { schema } from '../db/index.js';
+import { guildMemberCache } from '../core/members.js';
 import type { RegisteredMember } from './service.js';
 
 /** Guild members who have a Last.fm login, in the shape the crown service consumes. */
@@ -9,14 +10,7 @@ export async function gatherRegisteredMembers(
   db: Db,
   guild: Guild,
 ): Promise<RegisteredMember[]> {
-  // A full members.fetch() hits the gateway REQUEST_GUILD_MEMBERS op, which
-  // Discord rate-limits; doing it on every command trips GatewayRateLimitError
-  // on rapid calls. Fetch only when the cache is missing members — the
-  // GuildMembers intent keeps it current afterwards.
-  if (guild.members.cache.size < guild.memberCount) {
-    await guild.members.fetch().catch(() => undefined);
-  }
-  const members = guild.members.cache;
+  const members = await guildMemberCache(guild);
   const ids = [...members.filter((m) => !m.user.bot).keys()];
   if (ids.length === 0) return [];
 

--- a/test/commands/rym.test.ts
+++ b/test/commands/rym.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { EmbedBuilder } from 'discord.js';
 import { rymCommands } from '../../src/commands/rym.js';
 import { schema } from '../../src/db/index.js';
-import { makeFakeApp, makeFakeMessage } from '../helpers/fake.js';
+import { makeFakeApp, makeFakeMessage, withGuildMembers } from '../helpers/fake.js';
 
 const byName = (name: string) => rymCommands.find((c) => c.name === name)!;
 
@@ -487,5 +487,73 @@ describe('&srand', () => {
     const fake = makeFakeMessage({ content: '&srand' });
     await byName('srand').run({ app, message: fake.message, args: [] });
     expect(fake.replies[0]).toBe('you rolled the dice! http://rateyourmusic.com/misc/random');
+  });
+});
+
+describe('&rymsc', () => {
+  function setup(rymNames: (string | null)[]) {
+    const app = makeFakeApp(rymCommands);
+    rymNames.forEach((rymUsername, i) => {
+      app.db
+        .insert(schema.users)
+        .values({ discordUserId: `user-${i + 1}`, lastfmUsername: `lfm${i + 1}`, rymUsername })
+        .run();
+    });
+    const fake = makeFakeMessage({ content: '&rymsc' });
+    withGuildMembers(
+      fake,
+      rymNames.map((_, i) => `user-${i + 1}`),
+    );
+    return { app, fake };
+  }
+
+  const sent = (fake: ReturnType<typeof makeFakeMessage>) =>
+    (fake.payloads.at(-1)?.content as string) ?? fake.replies.at(-1)!;
+
+  it('lists every logged-in member alphabetically and deweights soundtracks', async () => {
+    const { app, fake } = setup(['zeta', 'Accel', 'monty']);
+    await byName('rymsc').run({ app, message: fake.message, args: [] });
+
+    expect(sent(fake)).toContain(
+      'https://rateyourmusic.com/charts/top/album,ep,comp,mixtape,djmix/all-time/' +
+        'u:Accel,monty,zeta/deweight:soundtrack/',
+    );
+    expect(sent(fake)).toContain('(3 users)');
+  });
+
+  it('skips members with no RYM username', async () => {
+    const { app, fake } = setup(['Accel', null]);
+    await byName('rymsc').run({ app, message: fake.message, args: [] });
+
+    expect(sent(fake)).toContain('u:Accel/');
+    expect(sent(fake)).toContain('(1 user)');
+  });
+
+  it('adds the genre and excl:ratings segments from flags', async () => {
+    const { app, fake } = setup(['Accel']);
+    await byName('rymsc').run({
+      app,
+      message: fake.message,
+      args: ['--exclude-rated', '-g', 'nature', 'recordings'],
+    });
+
+    expect(sent(fake)).toContain(
+      'g:nature%2drecordings/u:Accel/deweight:soundtrack/excl:ratings/',
+    );
+  });
+
+  it('replies with usage instead of a chart when a flag is wrong', async () => {
+    const { app, fake } = setup(['Accel']);
+    await byName('rymsc').run({ app, message: fake.message, args: ['--genre'] });
+
+    expect(fake.replies.at(-1)).toContain('&rymsc [--genre <genre>]');
+    expect(sent(fake)).not.toContain('rateyourmusic.com/charts');
+  });
+
+  it('refuses when nobody in the server is logged into rym', async () => {
+    const { app, fake } = setup([null]);
+    await byName('rymsc').run({ app, message: fake.message, args: [] });
+
+    expect(fake.replies.at(-1)).toBe('no one in this server is logged into rym.');
   });
 });

--- a/test/commands/rymChart.test.ts
+++ b/test/commands/rymChart.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildServerChartUrl,
+  genreSlug,
+  parseServerChartArgs,
+} from '../../src/commands/rymChart.js';
+
+const USERS = ['Accel', 'feastgood', 'grammatizator'];
+
+describe('genreSlug', () => {
+  it('lowercases and encodes the separating hyphen', () => {
+    expect(genreSlug('Nature Recordings')).toBe('nature%2drecordings');
+  });
+
+  it('treats an already-hyphenated genre the same as a spaced one', () => {
+    expect(genreSlug('trip-hop')).toBe('trip%2dhop');
+    expect(genreSlug('Trip Hop')).toBe('trip%2dhop');
+  });
+
+  it('collapses runs of punctuation and trims the edges', () => {
+    expect(genreSlug('  drum & bass  ')).toBe('drum%2dbass');
+  });
+});
+
+describe('buildServerChartUrl', () => {
+  const base = 'https://rateyourmusic.com/charts/top/album,ep,comp,mixtape,djmix/all-time/';
+
+  it('deweights soundtracks by default', () => {
+    expect(buildServerChartUrl({ usernames: USERS })).toBe(
+      `${base}u:Accel,feastgood,grammatizator/deweight:soundtrack/`,
+    );
+  });
+
+  it('appends excl:ratings after the deweight segment', () => {
+    expect(buildServerChartUrl({ usernames: USERS, excludeRated: true })).toBe(
+      `${base}u:Accel,feastgood,grammatizator/deweight:soundtrack/excl:ratings/`,
+    );
+  });
+
+  it('puts the genre segment before the user segment', () => {
+    expect(
+      buildServerChartUrl({
+        usernames: USERS,
+        genre: 'Nature Recordings',
+        excludeRated: true,
+      }),
+    ).toBe(
+      `${base}g:nature%2drecordings/u:Accel,feastgood,grammatizator/` +
+        `deweight:soundtrack/excl:ratings/`,
+    );
+  });
+
+  it('drops the deweight segment when soundtracks are kept', () => {
+    expect(buildServerChartUrl({ usernames: USERS, keepSoundtracks: true })).toBe(
+      `${base}u:Accel,feastgood,grammatizator/`,
+    );
+  });
+});
+
+describe('parseServerChartArgs', () => {
+  it('defaults to no genre, ratings included, soundtracks deweighted', () => {
+    expect(parseServerChartArgs([])).toEqual({
+      excludeRated: false,
+      keepSoundtracks: false,
+    });
+  });
+
+  it('reads a multi-word genre without quoting', () => {
+    expect(parseServerChartArgs(['-g', 'nature', 'recordings'])).toEqual({
+      genre: 'nature recordings',
+      excludeRated: false,
+      keepSoundtracks: false,
+    });
+  });
+
+  it('accepts flags in any order and stops the genre at the next flag', () => {
+    expect(
+      parseServerChartArgs(['--exclude-rated', '--genre', 'trip', 'hop', '--soundtracks']),
+    ).toEqual({
+      genre: 'trip hop',
+      excludeRated: true,
+      keepSoundtracks: true,
+    });
+  });
+
+  it('is case-insensitive about flag names', () => {
+    expect(parseServerChartArgs(['--Exclude-Rated']).excludeRated).toBe(true);
+  });
+
+  it('errors when the genre flag has nothing after it', () => {
+    expect(parseServerChartArgs(['--genre']).error).toBeDefined();
+  });
+
+  it('errors on an unknown flag', () => {
+    expect(parseServerChartArgs(['--top-2024']).error).toBeDefined();
+  });
+
+  it('errors on a bare argument that is not part of a genre', () => {
+    expect(parseServerChartArgs(['jazz']).error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

`-rymsc` (alias `-rsc`) replies with a RateYourMusic chart URL built from the RYM usernames of
every member of the server who is logged into RYM with the bot. Usernames are gathered from the
guild member list joined against `users.rym_username`, deduplicated, and sorted alphabetically, so
the same server always produces the same link. Members without a RYM username are simply absent,
and a server where nobody is logged in gets a plain refusal rather than a chart with an empty
`u:` segment.

Three modifiers, following the `--flag` convention already used by `-crowns`:

- `--genre <genre>` / `-g <genre>` — adds the `g:` segment. The rest of the line is consumed as the
  genre, so multi-word genres need no quoting: `-rsc -g nature recordings`.
- `--exclude-rated` — appends `excl:ratings/`, hiding releases already rated.
- `--soundtracks` — keeps soundtracks weighted normally. By default the URL carries
  `deweight:soundtrack/`.

Anything the parser doesn't understand — an unknown flag, a genre flag with nothing after it, a
stray bare word — replies with usage instead of quietly emitting a subtly wrong chart.

URL assembly and flag parsing live in a new pure module, `src/commands/rymChart.ts`, following the
`fm.ts` → `fmFormat.ts` split already in the repo. Segment order is load-bearing (RYM 404s a chart
whose filters are shuffled), so it is asserted directly in unit tests rather than only through a
Discord-coupled path.

The guild member-cache fetch — with its comment explaining why a blanket `members.fetch()` trips
`GatewayRateLimitError` — moved from `src/crowns/members.ts` into a shared
`src/core/members.ts#guildMemberCache`, so `-rymsc` reuses it instead of carrying a second copy of
a workaround that only misbehaves under load.

## Why

The server's combined RYM chart is a link people were building by hand, concatenating usernames
into the URL themselves. Every piece needed to generate it was already in the database:
`users.rym_username` has been populated by `-profile` since the 2.0 rewrite, and `src/commands/rym.ts`
is already twenty commands' worth of "interpolate a user row into a RYM URL". This is the
server-scoped sibling of those, with no network call, no Last.fm quota, and no new schema.

## Testing

19 new tests — 14 unit tests over `genreSlug` / `buildServerChartUrl` / `parseServerChartArgs`
(segment ordering, all four flag combinations, multi-word genres, every error path) and 5
command-level tests against the in-memory SQLite and fake `Message` (alphabetical ordering,
members without a RYM name, flag-driven segments, the usage bail-out, the empty-server refusal).

Full suite: 347 passing. Typecheck and lint clean.