### PR TITLE
fix(scripts): skip non-banner files when verifying img:pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ matching section.
 Entry format: `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`, then one `-` bullet per change, written for the
 people using the bot rather than for the diff.
 
+## [2.11.1] - 2026-08-27
+
+- `npm run img:pull` no longer reports macOS `.DS_Store` files as corrupt banner images. Only
+  content-addressed files are hash-checked; everything else is skipped and kept out of the zip.
+
 ## [2.11.0] - 2026-08-27
 
 - `-rymsc` (alias `-rsc`) links a RateYourMusic chart built from the combined ratings of everyone

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed1",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "feed1 — a Last.fm Discord bot",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/img-pull.sh
+++ b/scripts/img-pull.sh
@@ -51,9 +51,13 @@ corrupt=0
 total=0
 bytes=0
 while IFS= read -r file; do
+  expected="$(basename "$file")"
+  # only store.add() output is content-addressed, so only it can be checked this way.
+  # Finder drops .DS_Store into any directory it renders, and `${name%.*}` leaves ".DS"
+  # — a stem that can never be a digest, which read as corruption on every pull.
+  [[ "$expected" =~ ^[0-9a-f]{64}\.[a-z0-9]+$ ]] || continue
   total=$((total + 1))
   bytes=$((bytes + $(wc -c <"$file")))
-  expected="$(basename "$file")"
   expected="${expected%.*}"
   actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
   if [[ "$actual" != "$expected" ]]; then
@@ -64,10 +68,10 @@ while IFS= read -r file; do
     # prod's copy may be gone too, and a bad copy still beats none.
     mv "$file" "$file.corrupt"
   fi
-done < <(find "$DEST_DIR" -type f ! -name '*.corrupt')
+done < <(find "$DEST_DIR" -type f)
 
 rm -f "$DEST_ZIP.part"
-(cd "$DEST_DIR" && zip -r -q -X "$DEST_ZIP.part" . -x '*.corrupt') >/dev/null
+(cd "$DEST_DIR" && zip -r -q -X "$DEST_ZIP.part" . -x '*.corrupt' '*.DS_Store') >/dev/null
 mv "$DEST_ZIP.part" "$DEST_ZIP"
 
 guilds="$(find "$DEST_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"


### PR DESCRIPTION
## What

`npm run img:pull` verifies the banner pool by re-hashing every pulled file and comparing it to the
filename, which is the sha256 of the contents. That check was applied to *every* file under the
destination, not just the content-addressed ones. A macOS Finder `.DS_Store` has no digest stem —
`${name%.*}` leaves `.DS` — so it was reported `CORRUPT`, renamed to `.DS_Store.corrupt`, left out
of the zip, and the script exited non-zero even though all 218 real banners verified clean.

The verify loop now skips anything whose name is not `<64 hex>.<ext>`, and `.DS_Store` is excluded
from the zip alongside `.corrupt`. The `! -name '*.corrupt'` filter on `find` is dropped as
redundant — a `.corrupt` suffix already fails the new pattern.

## Why

The check is only meaningful over files `store.add()` wrote, since those are the only ones where
filename-equals-hash holds. Applying it more broadly turns any stray file into a permanent false
positive, which trains you to ignore a signal whose entire job is to be trusted — this pool is in
no other backup.

Verified by re-running `npm run img:pull`: exit 0, `all 218 file(s) match their content hash`, 218
banners in the zip. Lint and typecheck pass.